### PR TITLE
[Proposal] Remove 'How' section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,5 @@
 
 ...
 
-#### How?
-
-...
-
 ----
 CC @pusher/mobile


### PR DESCRIPTION
My proposal is that we remove 'How' section out from the template.
Reason for this is that code is in most cases self-explanatory.
Also we can get the context of 'How' out from the title and body
of the commit.

----
CC @pusher/mobile
