### PR TITLE
Set default to public

### DIFF
--- a/Source/PCCurrentUser.swift
+++ b/Source/PCCurrentUser.swift
@@ -95,7 +95,7 @@ public final class PCCurrentUser {
 
     public func createRoom(
         name: String,
-        isPrivate: Bool = true,
+        isPrivate: Bool = false,
         addUserIds userIds: [String]? = nil,
         completionHandler: @escaping RoomCompletionHandler
     ) {


### PR DESCRIPTION
### What?

Rooms should be public as a default value

[Trello ticket.](https://trello.com/c/zshh9ZE7/292-make-room-creation-default-to-public-in-sdk)

----
CC @pusher/mobile