### PR TITLE
Restructure token provider

### DIFF
--- a/Pusher Chat iOS Example/Pusher Chat iOS Example/AppDelegate.swift
+++ b/Pusher Chat iOS Example/Pusher Chat iOS Example/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let instanceId = "v1:api-deneb:2f354c91-269f-4820-93d2-5441219fdd23"
         let pusherChat = ChatManager(
             instanceId: instanceId,
-            tokenProvider: PCTokenProvider(userId: "test", url: "https://chatkit-test-token-provider.herokuapp.com/token?instance_id=v1:us1:1234"),
+            tokenProvider: PCTokenProvider(url: "https://chatkit-test-token-provider.herokuapp.com/token?instance_id=v1:us1:1234", userId: "test"),
             logger: HamLogger(),
             baseClient: PPBaseClient(host: "api-deneb.pusherplatform.io", insecure: true)
         )

--- a/Pusher Chat iOS Example/Pusher Chat iOS Example/AppDelegate.swift
+++ b/Pusher Chat iOS Example/Pusher Chat iOS Example/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let instanceId = "v1:api-deneb:2f354c91-269f-4820-93d2-5441219fdd23"
         let pusherChat = ChatManager(
             instanceId: instanceId,
-            tokenProvider: PCTestingTokenProvider(userId: "test", instanceId: instanceId),
+            tokenProvider: PCTokenProvider(userId: "test", url: "https://chatkit-test-token-provider.herokuapp.com/token?instance_id=v1:us1:1234"),
             logger: HamLogger(),
             baseClient: PPBaseClient(host: "api-deneb.pusherplatform.io", insecure: true)
         )

--- a/PusherChatkit/PusherChatkit.xcodeproj/project.pbxproj
+++ b/PusherChatkit/PusherChatkit.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		3397D4C21EC2017000DD5994 /* PCSynchronizedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3397D4C11EC2017000DD5994 /* PCSynchronizedArray.swift */; };
 		339CABD31EC3078200FDFB58 /* PCRoomDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339CABD21EC3078200FDFB58 /* PCRoomDelegate.swift */; };
 		33AE481E1EAE2D14006C27A6 /* PusherChatkit.h in Headers */ = {isa = PBXBuildFile; fileRef = 33346ABF1EAE1887002C58B8 /* PusherChatkit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		33B3DD9F1EF7E2F60050CA02 /* PCTestingTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B3DD9E1EF7E2F60050CA02 /* PCTestingTokenProvider.swift */; };
+		33B3DD9F1EF7E2F60050CA02 /* PCTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B3DD9E1EF7E2F60050CA02 /* PCTokenProvider.swift */; };
 		33D2A5AF1E39075100EA7549 /* DummyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D2A5AD1E39074800EA7549 /* DummyTests.swift */; };
 		A14E75AF1F604125009C55DD /* PCHTTPTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14E75AE1F604125009C55DD /* PCHTTPTokenProvider.swift */; };
 /* End PBXBuildFile section */
@@ -73,7 +73,7 @@
 		3397D4C11EC2017000DD5994 /* PCSynchronizedArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCSynchronizedArray.swift; sourceTree = "<group>"; };
 		339CABD21EC3078200FDFB58 /* PCRoomDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCRoomDelegate.swift; sourceTree = "<group>"; };
 		33AE481F1EAE4020006C27A6 /* Carthage.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = SOURCE_ROOT; };
-		33B3DD9E1EF7E2F60050CA02 /* PCTestingTokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCTestingTokenProvider.swift; sourceTree = "<group>"; };
+		33B3DD9E1EF7E2F60050CA02 /* PCTokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCTokenProvider.swift; sourceTree = "<group>"; };
 		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		33D2A5AD1E39074800EA7549 /* DummyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DummyTests.swift; path = ../Tests/DummyTests.swift; sourceTree = "<group>"; };
 		A14E75AE1F604125009C55DD /* PCHTTPTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCHTTPTokenProvider.swift; sourceTree = "<group>"; };
@@ -141,7 +141,7 @@
 				331421321ED33C1400D0B6DB /* PCTypingIndicatorManager.swift */,
 				331F9BD81EBC80FA00C3F678 /* PCPayloadDeserializer.swift */,
 				3397D4C11EC2017000DD5994 /* PCSynchronizedArray.swift */,
-				33B3DD9E1EF7E2F60050CA02 /* PCTestingTokenProvider.swift */,
+				33B3DD9E1EF7E2F60050CA02 /* PCTokenProvider.swift */,
 				33831C8C1A9CF61600B124F1 /* Supporting Files */,
 				33346ABF1EAE1887002C58B8 /* PusherChatkit.h */,
 				A14E75AE1F604125009C55DD /* PCHTTPTokenProvider.swift */,
@@ -315,7 +315,7 @@
 				3314212F1ED32AE700D0B6DB /* PCProgressCounter.swift in Sources */,
 				339CABD31EC3078200FDFB58 /* PCRoomDelegate.swift in Sources */,
 				3397D4C21EC2017000DD5994 /* PCSynchronizedArray.swift in Sources */,
-				33B3DD9F1EF7E2F60050CA02 /* PCTestingTokenProvider.swift in Sources */,
+				33B3DD9F1EF7E2F60050CA02 /* PCTokenProvider.swift in Sources */,
 				331421331ED33C1400D0B6DB /* PCTypingIndicatorManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/ChatManager.swift
+++ b/Source/ChatManager.swift
@@ -24,7 +24,7 @@ import PusherPlatform
         logger: PPLogger = PPDefaultLogger(),
         baseClient: PPBaseClient? = nil
     ) {
-        (tokenProvider as? PCTestingTokenProvider)?.logger = logger
+        (tokenProvider as? PCTokenProvider)?.logger = logger
         
         self.instance = Instance(
             instanceId: instanceId,

--- a/Source/PCTokenProvider.swift
+++ b/Source/PCTokenProvider.swift
@@ -3,8 +3,8 @@ import PusherPlatform
 
 public final class PCTokenProvider: PPTokenProvider {
 
-    public let userId: String
     public let url: String
+    public let userId: String
 
     let internalTokenProvider: PPHTTPEndpointTokenProvider
     public var logger: PPLogger? {
@@ -13,9 +13,9 @@ public final class PCTokenProvider: PPTokenProvider {
         }
     }
 
-    public init(userId: String, url: String) {
-        self.userId = userId
+    public init(url: String, userId: String) {
         self.url = url
+        self.userId = userId
 
         let tokenProvider = PPHTTPEndpointTokenProvider(
             url: url,

--- a/Source/PCTokenProvider.swift
+++ b/Source/PCTokenProvider.swift
@@ -1,9 +1,11 @@
 import Foundation
 import PusherPlatform
 
-public final class PCTestingTokenProvider: PPTokenProvider {
+public final class PCTokenProvider: PPTokenProvider {
 
     public let userId: String
+    public let url: String
+
     let internalTokenProvider: PPHTTPEndpointTokenProvider
     public var logger: PPLogger? {
         willSet {
@@ -11,17 +13,15 @@ public final class PCTestingTokenProvider: PPTokenProvider {
         }
     }
 
-    public init(userId: String, instanceId: String) {
+    public init(userId: String, url: String) {
         self.userId = userId
+        self.url = url
 
         let tokenProvider = PPHTTPEndpointTokenProvider(
-            url: "https://chatkit-test-token-provider.herokuapp.com/token",
+            url: url,
             requestInjector: { req -> PPHTTPEndpointTokenProviderRequest in
                 req.addQueryItems(
-                    [
-                        URLQueryItem(name: "user_id", value: userId),
-                        URLQueryItem(name: "instance", value: instanceId),
-                    ]
+                    [URLQueryItem(name: "user_id", value: userId)]
                 )
                 return req
             }


### PR DESCRIPTION
### What?

- `PCTestingTokenProvider` is now `PCTokenProvider`.
- `instance_id` was removed and it's not needed to be provided by the user as we will get it from the URL.

For example: `https://chatkit-test-token-provider.herokuapp.com/token?instance_id=v1:us1:1234`

----
CC @pusher/mobile