### PR TITLE
Remove PusherChat.h

### DIFF
--- a/Source/PusherChat.h
+++ b/Source/PusherChat.h
@@ -1,7 +1,0 @@
-#import <Foundation/Foundation.h>
-
-//! Project version number for PusherChatkit.
-FOUNDATION_EXPORT double PusherChatVersionNumber;
-
-//! Project version string for PusherChatkit.
-FOUNDATION_EXPORT const unsigned char PusherChatVersionString[];


### PR DESCRIPTION
### What?

I've just noticed that we still have `PusherChat.h` in the [`Source/`](https://github.com/pusher/chatkit-swift/tree/master/Source).
Should be removed as part of #37 but it probably sneaked out.

----
CC @pusher/mobile