### PR TITLE
Token provider update

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "pusher/pusher-platform-swift" ~> 0.1.31
+github "pusher/pusher-platform-swift" ~> 0.1.32

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "pusher/pusher-platform-swift" "0.1.31"
+github "pusher/pusher-platform-swift" "0.1.32"

--- a/PusherChatkit.podspec
+++ b/PusherChatkit.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'Source/*.swift'
 
-  s.dependency 'PusherPlatform', '~> 0.1.31'
+  s.dependency 'PusherPlatform', '~> 0.1.32'
 
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.11'

--- a/Source/ChatManager.swift
+++ b/Source/ChatManager.swift
@@ -79,13 +79,8 @@ import PusherPlatform
         self.instance.subscribeWithResume(
             with: &resumableSub,
             using: subscribeRequest,
-            //            onOpening: onOpening,
-            //            onOpen: onOpen,
-            //            onResuming: onResuming,
             onEvent: self.userSubscription!.handleEvent,
-            onEnd: { _, _, _ in
-                print("ENDED")
-            },
+            onEnd: { _, _, _ in },
             onError: { error in
                 completionHandler(nil, error)
             }


### PR DESCRIPTION
### What?

Allow `PCTokenProvider` to take a `requestInjector`

### Why?

To avoid the need to drop down into using `PPHTTPEndpointTokenProvider` from `PusherPlatform`

----
CC @pusher/mobile