### PR TITLE
Add --repo-update flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ end
 Then, run the following command:
 
 ```bash
-$ pod install
+$ pod install --repo-update
 ```
 
 ### Carthage

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ end
 Then, run the following command:
 
 ```bash
-$ pod install --repo-update
+$ pod install
 ```
+
+> Optionally use `--repo-update` flag to ensure the specs repository is aware of the latest version of PusherChatkit.
 
 ### Carthage
 


### PR DESCRIPTION
### What?

Add `--repo-update` flag.

#### Why?

Some users might have an outdated CocoaPods Specs repo, and because our pod is quite new it might fail to install Chatkit dependency. By adding flag `--repo-update` we can be sure that this will not happen.
There is just one downside, it might take longer to integrate the dependency into the project.

----
CC @pusher/mobile