### PR TITLE
🐛 Fixed bug where the user_id was not retrieved

### DIFF
--- a/Source/PCUserSubscription.swift
+++ b/Source/PCUserSubscription.swift
@@ -54,7 +54,7 @@ public final class PCUserSubscription {
             return
         }
 
-        let userId = json["user_id"] as? String
+        let userId = apiEventData["user_id"] as? String
 
         self.instance.logger.log("Received event name: \(eventNameString), and data: \(apiEventData)", logLevel: .verbose)
 


### PR DESCRIPTION
🐛 Fixed bug where the user_id was not retrieved

### What?
The `user_id` key is not in the root object. Therefore `user_id` will be `nil` as it was not being retrieved properly thus causing a crash.

...

----
CC @pusher/mobile
