### PR TITLE
Cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,6 @@ This means that importing PusherPlatform should never need to be done anymore.
 - User(s) can be added or removed from the room by providing ids or user objects.
 - Improved logging
 
-
 ### Changed
 - `PULL_REQUEST_TEMPLATE.md` template
 - `PusherChat` -> `PusherChatkit`
@@ -198,11 +197,11 @@ This means that importing PusherPlatform should never need to be done anymore.
 - Move to deneb cluster
 
 ## [0.2.8](https://github.com/pusher/chatkit-swift/compare/0.2.7...0.2.8) - 2017-08-01
+
 ### Added
 - `avatarURL` property in `PCCurrentUser` class
 - `isPrivate` property in `PCRoom` class
 - Default implementations of `PCRoomDelegate` and `PCChatManagerDelegate` protocol methods
-
 
 ### Changed
 - `PCRoomDelegate` delegate methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-swift/compare/0.5.0...HEAD)
 
+### Changed
+
+- `ChatManager` requires a `userId` be provided when it is instantiated
+- `PCTokenProvider` no longer takes a `userId` parameter when it is instantiated
+- The completion handler passed to `connect` of `ChatManager` will now only be called once the following has completed, either successfully or unsuccessfully:
+    * User subscription has been established
+    * Presence subscription has been established
+    * Initial cursors fetch has completed (getting initial values for read cursors of the current user for the rooms that they are a member of)
+    * Initial users fetch has completed (getting initial information about user IDs that were seen in the list of members of the rooms that the current user is a member of)
+
+### Added
+
+- Support for read cursors:
+    * `setCursor` added to `PCCurrentUser`, usage of which looks like:
+
+    ```swift
+    currentUser.setCursor(position: 123, roomId: myRoom.id) { error in
+        guard error == nil else {
+            print("Error setting cursor: \(error!.localizedDescription)")
+            return
+        }
+        print("Succeeded in setting cursor")
+    }
+    ```
+    * `cursorSet` function added to `PCRoomDelegate` so that you can be notified of other members in the room updating their read cursors; the function looks like:
+
+    ```swift
+    func cursorSet(cursor: PCCursor) {
+        print("Cursor set for \(cursor.user.displayName) at position \(cursor.position)")
+    }
+    ```
+
 ## [0.5.0](https://github.com/pusher/chatkit-swift/compare/0.4.3...0.5.0) - 2018-01-26
 
 ### Changed

--- a/ChatkitiOSExample/ChatkitiOSExample/ViewController.swift
+++ b/ChatkitiOSExample/ChatkitiOSExample/ViewController.swift
@@ -131,6 +131,10 @@ extension ViewController: PCRoomDelegate {
         print("\(user.displayName) went offline")
         print(self.currentRoom!.users.map { "\($0.id), \($0.name!), \($0.presenceState.rawValue)" }.joined(separator: "; "))
     }
+
+    func cursorSet(cursor: PCCursor) {
+        print("Cursor set for \(cursor.user.displayName) at position \(cursor.position)")
+    }
 }
 
 extension ViewController: PCChatManagerDelegate {

--- a/PusherChatkit/PusherChatkit.xcodeproj/project.pbxproj
+++ b/PusherChatkit/PusherChatkit.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		334B9A2D1ECCA16A007A3D3B /* PCRoomStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334B9A2C1ECCA16A007A3D3B /* PCRoomStore.swift */; };
 		334B9A311ECD98A7007A3D3B /* PCBasicMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334B9A301ECD98A7007A3D3B /* PCBasicMessage.swift */; };
 		334B9A331ECD98FA007A3D3B /* PCBasicMessageEnricher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334B9A321ECD98FA007A3D3B /* PCBasicMessageEnricher.swift */; };
+		3361E7C12028753100F50580 /* PCConnectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3361E7C02028753100F50580 /* PCConnectionCoordinator.swift */; };
 		3388D5EF1EAE4DA90072A742 /* ChatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3388D5EE1EAE4DA90072A742 /* ChatManager.swift */; };
 		3388D5F11EAE4DD40072A742 /* PCChatManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3388D5F01EAE4DD40072A742 /* PCChatManagerDelegate.swift */; };
 		3388D5F31EAE4DFB0072A742 /* PCRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3388D5F21EAE4DFB0072A742 /* PCRoom.swift */; };
@@ -35,6 +36,11 @@
 		33BA563C200E634C00FFC587 /* PCAttachmentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA563B200E634C00FFC587 /* PCAttachmentType.swift */; };
 		33BA563E200E63DF00FFC587 /* PCFetchedAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA563D200E63DF00FFC587 /* PCFetchedAttachment.swift */; };
 		33BA5640200E640600FFC587 /* PCAttachmentUploadResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA563F200E640600FFC587 /* PCAttachmentUploadResponse.swift */; };
+		33C5D8F5202082EB00E826FB /* PCBasicCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C5D8F4202082EB00E826FB /* PCBasicCursor.swift */; };
+		33C5D8F72020837100E826FB /* PCCursorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C5D8F62020837100E826FB /* PCCursorType.swift */; };
+		33C5D8F92020842200E826FB /* PCCursorSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C5D8F82020842200E826FB /* PCCursorSubscription.swift */; };
+		33C5D8FB2020854A00E826FB /* PCCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C5D8FA2020854A00E826FB /* PCCursor.swift */; };
+		33C5D8FD2020AA4C00E826FB /* PCBasicCursorEnricher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C5D8FC2020AA4C00E826FB /* PCBasicCursorEnricher.swift */; };
 		33D2A5AF1E39075100EA7549 /* DummyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D2A5AD1E39074800EA7549 /* DummyTests.swift */; };
 		33E3EBC7200E2368003D888D /* PPTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E3EBC6200E2368003D888D /* PPTypealiases.swift */; };
 /* End PBXBuildFile section */
@@ -64,6 +70,7 @@
 		334B9A2C1ECCA16A007A3D3B /* PCRoomStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCRoomStore.swift; sourceTree = "<group>"; };
 		334B9A301ECD98A7007A3D3B /* PCBasicMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCBasicMessage.swift; sourceTree = "<group>"; };
 		334B9A321ECD98FA007A3D3B /* PCBasicMessageEnricher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCBasicMessageEnricher.swift; sourceTree = "<group>"; };
+		3361E7C02028753100F50580 /* PCConnectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCConnectionCoordinator.swift; sourceTree = "<group>"; };
 		33831C891A9CF61600B124F1 /* PusherChatkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PusherChatkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		33831C8D1A9CF61600B124F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		33831C941A9CF61600B124F1 /* PusherChatkitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PusherChatkitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,6 +90,11 @@
 		33BA563D200E63DF00FFC587 /* PCFetchedAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCFetchedAttachment.swift; sourceTree = "<group>"; };
 		33BA563F200E640600FFC587 /* PCAttachmentUploadResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCAttachmentUploadResponse.swift; sourceTree = "<group>"; };
 		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
+		33C5D8F4202082EB00E826FB /* PCBasicCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBasicCursor.swift; sourceTree = "<group>"; };
+		33C5D8F62020837100E826FB /* PCCursorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCCursorType.swift; sourceTree = "<group>"; };
+		33C5D8F82020842200E826FB /* PCCursorSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCCursorSubscription.swift; sourceTree = "<group>"; };
+		33C5D8FA2020854A00E826FB /* PCCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCCursor.swift; sourceTree = "<group>"; };
+		33C5D8FC2020AA4C00E826FB /* PCBasicCursorEnricher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBasicCursorEnricher.swift; sourceTree = "<group>"; };
 		33D2A5AD1E39074800EA7549 /* DummyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DummyTests.swift; path = ../Tests/DummyTests.swift; sourceTree = "<group>"; };
 		33E3EBC6200E2368003D888D /* PPTypealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPTypealiases.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -128,6 +140,7 @@
 			isa = PBXGroup;
 			children = (
 				3388D5EE1EAE4DA90072A742 /* ChatManager.swift */,
+				3361E7C02028753100F50580 /* PCConnectionCoordinator.swift */,
 				3388D5F61EAE4E330072A742 /* PCCurrentUser.swift */,
 				3388D5FC1EAE4EAC0072A742 /* PCUserSubscription.swift */,
 				331421341EDD8CDC00D0B6DB /* PCPresenceSubscription.swift */,
@@ -154,6 +167,11 @@
 				33BA563B200E634C00FFC587 /* PCAttachmentType.swift */,
 				33BA563D200E63DF00FFC587 /* PCFetchedAttachment.swift */,
 				33BA563F200E640600FFC587 /* PCAttachmentUploadResponse.swift */,
+				33C5D8F4202082EB00E826FB /* PCBasicCursor.swift */,
+				33C5D8FA2020854A00E826FB /* PCCursor.swift */,
+				33C5D8F62020837100E826FB /* PCCursorType.swift */,
+				33C5D8F82020842200E826FB /* PCCursorSubscription.swift */,
+				33C5D8FC2020AA4C00E826FB /* PCBasicCursorEnricher.swift */,
 				33E3EBC6200E2368003D888D /* PPTypealiases.swift */,
 				33831C8C1A9CF61600B124F1 /* Supporting Files */,
 				33346ABF1EAE1887002C58B8 /* PusherChatkit.h */,
@@ -308,8 +326,10 @@
 				331421371EDDA91A00D0B6DB /* PCPresencePayload.swift in Sources */,
 				3388D5FB1EAE4E640072A742 /* PCRoomSubscription.swift in Sources */,
 				334B9A311ECD98A7007A3D3B /* PCBasicMessage.swift in Sources */,
+				3361E7C12028753100F50580 /* PCConnectionCoordinator.swift in Sources */,
 				331421311ED32B5F00D0B6DB /* PCBasicUser.swift in Sources */,
 				3388D5EF1EAE4DA90072A742 /* ChatManager.swift in Sources */,
+				33C5D8F5202082EB00E826FB /* PCBasicCursor.swift in Sources */,
 				334B9A331ECD98FA007A3D3B /* PCBasicMessageEnricher.swift in Sources */,
 				3388D5F91EAE4E4A0072A742 /* PCUser.swift in Sources */,
 				331F9BD91EBC80FA00C3F678 /* PCPayloadDeserializer.swift in Sources */,
@@ -320,18 +340,22 @@
 				33BA563C200E634C00FFC587 /* PCAttachmentType.swift in Sources */,
 				331421351EDD8CDC00D0B6DB /* PCPresenceSubscription.swift in Sources */,
 				3336C8151EE045FE005EB69A /* PCRoomUserStore.swift in Sources */,
+				33C5D8FD2020AA4C00E826FB /* PCBasicCursorEnricher.swift in Sources */,
 				33023E23200CB4A4001937C6 /* PCAttachment.swift in Sources */,
 				334B9A2D1ECCA16A007A3D3B /* PCRoomStore.swift in Sources */,
 				3388D5F51EAE4E100072A742 /* PCMessage.swift in Sources */,
 				3388D5F71EAE4E330072A742 /* PCCurrentUser.swift in Sources */,
 				3388D5F11EAE4DD40072A742 /* PCChatManagerDelegate.swift in Sources */,
 				3388D5F31EAE4DFB0072A742 /* PCRoom.swift in Sources */,
+				33C5D8F72020837100E826FB /* PCCursorType.swift in Sources */,
 				3314212F1ED32AE700D0B6DB /* PCProgressCounter.swift in Sources */,
 				33BA563E200E63DF00FFC587 /* PCFetchedAttachment.swift in Sources */,
 				339CABD31EC3078200FDFB58 /* PCRoomDelegate.swift in Sources */,
+				33C5D8FB2020854A00E826FB /* PCCursor.swift in Sources */,
 				3397D4C21EC2017000DD5994 /* PCSynchronizedArray.swift in Sources */,
 				33B3DD9F1EF7E2F60050CA02 /* PCTokenProvider.swift in Sources */,
 				33E3EBC7200E2368003D888D /* PPTypealiases.swift in Sources */,
+				33C5D8F92020842200E826FB /* PCCursorSubscription.swift in Sources */,
 				331421331ED33C1400D0B6DB /* PCTypingIndicatorManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -110,8 +110,4 @@ import PusherPlatform
             room.subscription?.resumableSubscription.end()
         }
     }
-
-    //    fileprivate func onUserSubscriptionStateChange(newState: ) {
-    //        self.delegate?.userSubscriptionStateChanged(from: <#T##PCUserSubscriptionState#>, to: <#T##PCUserSubscriptionState#>)
-    //    }
 }

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -192,8 +192,7 @@ import PusherPlatform
             connectionCoordinator: connectionCoordinator
         )
 
-        // TODO: Fix this stuff
-
+        // TODO: Decide what to do with onEnd
         self.instance.subscribeWithResume(
             with: &resumableSub,
             using: subscribeRequest,

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -199,7 +199,7 @@ import PusherPlatform
             onEvent: self.userSubscription!.handleEvent,
             onEnd: { _, _, _ in },
             onError: { error in
-                completionHandler(nil, error)
+                self.connectionCoordinator.connectionEventCompleted(PCConnectionEvent(currentUser: nil, error: error))
             }
         )
 

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -4,6 +4,11 @@ import PusherPlatform
 @objc public class ChatManager: NSObject {
     public let instance: Instance
     public let filesInstance: Instance
+    public let cursorsInstance: Instance
+
+    public let userId: String
+    public let pathFriendlyUserId: String
+
     public internal(set) var userSubscription: PCUserSubscription?
 
     public var currentUser: PCCurrentUser? {
@@ -11,6 +16,8 @@ import PusherPlatform
     }
 
     let userStore: PCGlobalUserStore
+
+    let connectionCoordinator: PCConnectionCoordinator
 
     // TODO: Do we need this here? Should it instead just live on the PCCurrentUser?
     public var users: Set<PCUser> {
@@ -20,6 +27,7 @@ import PusherPlatform
     public init(
         instanceLocator: String,
         tokenProvider: PPTokenProvider,
+        userId: String,
         logger: PPLogger = PPDefaultLogger(),
         baseClient: PPBaseClient? = nil
     ) {
@@ -46,23 +54,124 @@ import PusherPlatform
             logger: logger
         )
 
-        (tokenProvider as? PCTokenProvider)?.logger = logger
+        self.cursorsInstance = Instance(
+            locator: instanceLocator,
+            serviceName: "chatkit_cursors",
+            serviceVersion: "v1",
+            tokenProvider: tokenProvider,
+            client: baseClient,
+            logger: logger
+        )
+
+        self.connectionCoordinator = PCConnectionCoordinator(logger: logger)
+
+        if let tokenProvider = tokenProvider as? PCTokenProvider {
+            tokenProvider.userId = userId
+            tokenProvider.logger = logger
+        }
         self.userStore = PCGlobalUserStore(instance: self.instance)
+        self.userId = userId
+
+        let allowedCharacterSet = CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[] ").inverted
+        // TODO: When can percent encoding fail?
+        self.pathFriendlyUserId = userId.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? userId
     }
 
     public func addConnectCompletionHandler(completionHandler: @escaping (PCCurrentUser?, Error?) -> Void) {
-        guard let userSub = userSubscription else {
-            self.instance.logger.log("userSubscription is nil so unable to add a connectCompletionHandler", logLevel: .debug)
-            return
-        }
-
-        userSub.connectCompletionHandlers.append(completionHandler)
+        connectionCoordinator.addConnectionCompletionHandler(completionHandler)
     }
 
     public func connect(
         delegate: PCChatManagerDelegate,
         completionHandler: @escaping (PCCurrentUser?, Error?) -> Void
     ) {
+        addConnectCompletionHandler(completionHandler: completionHandler)
+        connectionCoordinator.connectionEventHandlers.append(
+            PCConnectionEventHandler(
+                handler: { [weak self] events in
+                    guard let strongSelf = self else {
+                        print("self is nil when calling connection completion handler")
+                        return
+                    }
+
+                    guard events.count == 2 else {
+                        strongSelf.instance.logger.log(
+                            "Expected 2 events to be provided to connection event handler, but received \(events.count)",
+                            logLevel: .error
+                        )
+                        return
+                    }
+
+                    var currentUser: PCCurrentUser!
+                    var roomIdsToCursors: [Int: PCBasicCursor]!
+
+                    for event in events {
+                        switch event.result {
+                        case .userSubscriptionInit(let curUser, let error):
+                            guard curUser != nil else {
+                                strongSelf.instance.logger.log(
+                                    "Error when getting current user object from connection event handler when about to set cursors: \(error!.localizedDescription)",
+                                    logLevel: .error
+                                )
+                                return
+                            }
+                            currentUser = curUser!
+                        case .initialCursorsFetch(let idsToCursors, let error):
+                            guard idsToCursors != nil else {
+                                strongSelf.instance.logger.log(
+                                    "Error when getting room ids to basic cursors object from connection event handler when about to set cursors: \(error!.localizedDescription)",
+                                    logLevel: .error
+                                )
+                                return
+                            }
+                            roomIdsToCursors = idsToCursors!
+                        default:
+                            break
+                        }
+                    }
+
+                    roomIdsToCursors.forEach { roomIdToCursor in
+                        guard let room = currentUser.rooms.first(where: { $0.id == roomIdToCursor.key }) else {
+                            strongSelf.instance.logger.log(
+                                "Received an initial cursor for room \(roomIdToCursor.key) but the current user object didn't know about the room",
+                                logLevel: .debug
+                            )
+                            return
+                        }
+                        strongSelf.instance.logger.log(
+                            "Setting current user's cursor: (\(roomIdToCursor.value), for room \(room.name)",
+                            logLevel: .verbose
+                        )
+                        room.currentUserCursor = .set(roomIdToCursor.value)
+                    }
+
+                    let roomIdsFromCursorsData = roomIdsToCursors.map { $0.key }
+                    currentUser.rooms.filter { !roomIdsFromCursorsData.contains($0.id) }.forEach {
+                        $0.currentUserCursor = .unset
+                    }
+
+                    // TODO: Does this stuff need to be done synchronously?
+                    currentUser.pendingRoomSubscriptions.forEach { roomSubInfo in
+                        strongSelf.instance.logger.log(
+                            "Processing pending room subscription for room: \(roomSubInfo.room.debugDescription)",
+                            logLevel: .verbose
+                        )
+                        if let messageLimit = roomSubInfo.messageLimit {
+                            currentUser.subscribeToRoom(
+                                room: roomSubInfo.room,
+                                roomDelegate: roomSubInfo.roomDelegate,
+                                messageLimit: messageLimit
+                            )
+                        } else {
+                            currentUser.subscribeToRoom(room: roomSubInfo.room, roomDelegate: roomSubInfo.roomDelegate)
+                        }
+                    }
+                    currentUser.pendingRoomSubscriptions = []
+                },
+                dependencies: [PCUserSubscriptionInitEvent, PCInitialCursorsFetchCompletedEvent]
+            )
+        )
+
         let path = "/users"
         let subscribeRequest = PPRequestOptions(method: HTTPMethod.SUBSCRIBE.rawValue, path: path)
 
@@ -74,17 +183,13 @@ import PusherPlatform
         self.userSubscription = PCUserSubscription(
             instance: self.instance,
             filesInstance: self.filesInstance,
+            cursorsInstance: self.cursorsInstance,
             resumableSubscription: resumableSub,
             userStore: self.userStore,
             delegate: delegate,
-            connectCompletionHandler: { user, error in
-                guard let cUser = user else {
-                    completionHandler(nil, error)
-                    return
-                }
-
-                completionHandler(cUser, nil)
-            }
+            userId: userId,
+            pathFriendlyUserId: pathFriendlyUserId,
+            connectionCoordinator: connectionCoordinator
         )
 
         // TODO: Fix this stuff
@@ -98,16 +203,59 @@ import PusherPlatform
                 completionHandler(nil, error)
             }
         )
+
+        let getCursorsPath = "/cursors/\(PCCursorType.read.rawValue)/users/\(self.pathFriendlyUserId)"
+        let cursorsRequestOptions = PPRequestOptions(method: HTTPMethod.GET.rawValue, path: getCursorsPath)
+
+        self.cursorsInstance.requestWithRetry(
+            using: cursorsRequestOptions,
+            onSuccess: { data in
+                guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) else {
+                    self.connectionCoordinator.connectionEventCompleted(
+                        PCConnectionEvent(roomIdsToBasicCursors: nil, error: PCError.failedToDeserializeJSON(data))
+                    )
+                    return
+                }
+
+                guard let cursorsPayload = jsonObject as? [[String: Any]] else {
+                    self.connectionCoordinator.connectionEventCompleted(
+                        PCConnectionEvent(roomIdsToBasicCursors: nil, error: PCError.failedToCastJSONObjectToDictionary(jsonObject))
+                    )
+                    return
+                }
+
+                var roomIdsToBasicCursors: [Int: PCBasicCursor] = [:]
+                cursorsPayload.forEach { cursorPayload in
+                    do {
+                        let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(cursorPayload)
+                        roomIdsToBasicCursors[basicCursor.roomId] = basicCursor
+                    } catch let err {
+                        self.instance.logger.log(err.localizedDescription, logLevel: .debug)
+                    }
+                }
+
+                self.connectionCoordinator.connectionEventCompleted(
+                    PCConnectionEvent(roomIdsToBasicCursors: roomIdsToBasicCursors, error: nil)
+                )
+            },
+            onError: { err in
+                self.instance.logger.log("Error fetching initial cursors for user: \(err.localizedDescription)", logLevel: .debug)
+                self.connectionCoordinator.connectionEventCompleted(
+                    PCConnectionEvent(roomIdsToBasicCursors: nil, error: err)
+                )
+            }
+        )
     }
 
     // TODO: Maybe we need some sort of ChatManagerConnectionState?
 
     public func disconnect() {
         // End all subscriptions
-        self.userSubscription?.resumableSubscription.end()
-        self.currentUser?.presenceSubscription?.end()
-        self.currentUser?.rooms.forEach { room in
+        userSubscription?.resumableSubscription.end()
+        currentUser?.presenceSubscription?.end()
+        currentUser?.rooms.forEach { room in
             room.subscription?.resumableSubscription.end()
         }
+        connectionCoordinator.reset()
     }
 }

--- a/Sources/PCBasicCursor.swift
+++ b/Sources/PCBasicCursor.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public struct PCBasicCursor {
-    public let cursorType: PCCursorType
+    public let type: PCCursorType
     public let position: Int
     public let roomId: Int
     public let updatedAt: String

--- a/Sources/PCBasicCursor.swift
+++ b/Sources/PCBasicCursor.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  PusherChatkit
+//
+//  Created by Hamilton Chapman on 30/01/2018.
+//
+
+import Foundation

--- a/Sources/PCBasicCursor.swift
+++ b/Sources/PCBasicCursor.swift
@@ -1,8 +1,9 @@
-//
-//  File.swift
-//  PusherChatkit
-//
-//  Created by Hamilton Chapman on 30/01/2018.
-//
-
 import Foundation
+
+public struct PCBasicCursor {
+    public let cursorType: PCCursorType
+    public let position: Int
+    public let roomId: Int
+    public let updatedAt: String
+    public let userId: String
+}

--- a/Sources/PCBasicCursorEnricher.swift
+++ b/Sources/PCBasicCursorEnricher.swift
@@ -29,7 +29,7 @@ final class PCBasicCursorEnricher {
             }
 
             let cursor = PCCursor(
-                type: basicCursor.cursorType,
+                type: basicCursor.type,
                 position: basicCursor.position,
                 room: strongSelf.room,
                 updatedAt: basicCursor.updatedAt,

--- a/Sources/PCBasicCursorEnricher.swift
+++ b/Sources/PCBasicCursorEnricher.swift
@@ -1,0 +1,42 @@
+import Foundation
+import PusherPlatform
+
+final class PCBasicCursorEnricher {
+    public let userStore: PCGlobalUserStore
+    public let room: PCRoom
+    let logger: PPLogger
+
+    init(userStore: PCGlobalUserStore, room: PCRoom, logger: PPLogger) {
+        self.userStore = userStore
+        self.room = room
+        self.logger = logger
+    }
+
+    func enrich(_ basicCursor: PCBasicCursor, completionHandler: @escaping (PCCursor?, Error?) -> Void) {
+        self.userStore.user(id: basicCursor.userId) { [weak self] user, err in
+            guard let strongSelf = self else {
+                print("self is nil when user store returns user while enriching cursor")
+                return
+            }
+
+            guard let user = user, err == nil else {
+                strongSelf.logger.log(
+                    "Unable to find user with id \(basicCursor.userId) while enriching cursor. Error: \(err!.localizedDescription)",
+                    logLevel: .debug
+                )
+                completionHandler(nil, err!)
+                return
+            }
+
+            let cursor = PCCursor(
+                type: basicCursor.cursorType,
+                position: basicCursor.position,
+                room: strongSelf.room,
+                updatedAt: basicCursor.updatedAt,
+                user: user
+            )
+
+            completionHandler(cursor, nil)
+        }
+    }
+}

--- a/Sources/PCConnectionCoordinator.swift
+++ b/Sources/PCConnectionCoordinator.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+public class PCConnectionCoordinator {
+    private var queue = DispatchQueue(label: "com.pusher.chatkit.connection-coordinator")
+    var completedConnectionEvents: Set<PCConnectionEvent> = []
+    var connectionEventHandlers: [PCConnectionEventHandler] = []
+    var logger: PCLogger
+
+    init(logger: PCLogger) {
+        self.logger = logger
+    }
+
+    func connectionEventCompleted(_ event: PCConnectionEvent) {
+        queue.async {
+            self.logger.log("\(event.debugDescription) completed", logLevel: .verbose)
+
+            let insertResult = self.completedConnectionEvents.insert(event)
+            guard insertResult.inserted else {
+                self.logger.log(
+                    "\(event.debugDescription) completion communicated to connection coordinator, but event of same type already stored",
+                    logLevel: .debug
+                )
+                return
+            }
+
+            var completionHandlersToCall: [PCConnectionEventHandler] = []
+            var completionHandlersToKeep: [PCConnectionEventHandler] = []
+
+            for connectionEventHanlder in self.connectionEventHandlers {
+                if connectionEventHanlder.dependencies.isSubset(of: self.completedConnectionEvents) {
+                    completionHandlersToCall.append(connectionEventHanlder)
+                } else {
+                    completionHandlersToKeep.append(connectionEventHanlder)
+                }
+            }
+
+            self.connectionEventHandlers = completionHandlersToKeep
+
+            completionHandlersToCall.forEach { completionHandler in
+                let eventsToCallHandlerWith = Array(self.completedConnectionEvents.intersection(completionHandler.dependencies))
+                completionHandler.handler(eventsToCallHandlerWith)
+            }
+
+            if self.completedConnectionEvents == allConnectionEvents {
+                self.reset(alreadyInCoordinatorQueue: true)
+            }
+        }
+    }
+
+    func addConnectionCompletionHandler(_ handler: @escaping (PCCurrentUser?, Error?) -> Void) {
+        connectionEventHandlers.append(
+            PCConnectionEventHandler(
+                handler: { events in
+                    for event in events {
+                        switch event.result {
+                        case .userSubscriptionInit(let currentUser, let error):
+                            handler(currentUser, error)
+                        default:
+                            break
+                        }
+                    }
+                },
+                dependencies: allConnectionEvents
+            )
+        )
+    }
+
+    func reset(alreadyInCoordinatorQueue: Bool = false) {
+        if alreadyInCoordinatorQueue {
+            completedConnectionEvents = []
+        } else {
+            queue.async { self.completedConnectionEvents = [] }
+        }
+    }
+}
+
+public class PCConnectionEventHandler {
+    public let handler: ([PCConnectionEvent]) -> Void
+    public let dependencies: Set<PCConnectionEvent>
+
+    public init(handler: @escaping ([PCConnectionEvent]) -> Void, dependencies: Set<PCConnectionEvent>) {
+        self.handler = handler
+        self.dependencies = dependencies
+    }
+}
+
+// TODO: Sourcery should be used for all of this generation stuff
+public class PCConnectionEvent {
+    public let type: PCConnectionEventType
+    public let result: PCConnectionEventResult
+
+    fileprivate init(type: PCConnectionEventType, result: PCConnectionEventResult) {
+        self.type = type
+        self.result = result
+    }
+
+    convenience init(currentUser: PCCurrentUser?, error: Error?) {
+        self.init(type: .userSubscriptionInit, result: .userSubscriptionInit(currentUser: currentUser, error: error))
+    }
+
+    convenience init(presenceSubscription: PCPresenceSubscription?, error: Error?) {
+        self.init(type: .presenceSubscriptionInit, result: .presenceSubscriptionInit(presenceSubscription: presenceSubscription, error: error))
+    }
+
+    convenience init(roomIdsToBasicCursors: [Int: PCBasicCursor]?, error: Error?) {
+        self.init(type: .initialCursorsFetch, result: .initialCursorsFetch(roomIdsToBasicCursors: roomIdsToBasicCursors, error: error))
+    }
+
+    convenience init(users: [PCUser]?, error: Error?) {
+        self.init(type: .initialUsersFetch, result: .initialUsersFetch(users: users, error: error))
+    }
+
+    fileprivate static func userSubscriptionInit() -> PCConnectionEvent {
+        return PCConnectionEvent(type: .userSubscriptionInit, result: .userSubscriptionInit(currentUser: nil, error: nil))
+    }
+
+    fileprivate static func presenceSubscriptionInit() -> PCConnectionEvent {
+        return PCConnectionEvent(type: .presenceSubscriptionInit, result: .presenceSubscriptionInit(presenceSubscription: nil, error: nil))
+    }
+
+    fileprivate static func initialCursorsFetchCompleted() -> PCConnectionEvent {
+        return PCConnectionEvent(type: .initialCursorsFetch, result: .initialCursorsFetch(roomIdsToBasicCursors: nil, error: nil))
+    }
+
+    fileprivate static func initialUsersFetchCompleted() -> PCConnectionEvent {
+        return PCConnectionEvent(type: .initialUsersFetch, result: .initialUsersFetch(users: nil, error: nil))
+    }
+}
+
+extension PCConnectionEvent: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "Connection event type: \(self.type.rawValue), with result: \(self.result.debugDescription)"
+    }
+}
+
+public let PCUserSubscriptionInitEvent = PCConnectionEvent.userSubscriptionInit()
+public let PCPresenceSubscriptionInitEvent = PCConnectionEvent.presenceSubscriptionInit()
+public let PCInitialCursorsFetchCompletedEvent = PCConnectionEvent.initialCursorsFetchCompleted()
+public let PCInitialUsersFetchCompletedEvent = PCConnectionEvent.initialUsersFetchCompleted()
+
+fileprivate let allConnectionEvents: Set<PCConnectionEvent> = [
+    PCUserSubscriptionInitEvent,
+    PCPresenceSubscriptionInitEvent,
+    PCInitialCursorsFetchCompletedEvent,
+    PCInitialUsersFetchCompletedEvent
+]
+
+extension PCConnectionEvent: Hashable {
+    public var hashValue: Int {
+        return self.type.hashValue
+    }
+
+    public static func ==(lhs: PCConnectionEvent, rhs: PCConnectionEvent) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+}
+
+public enum PCConnectionEventResult {
+    case userSubscriptionInit(currentUser: PCCurrentUser?, error: Error?)
+    case presenceSubscriptionInit(presenceSubscription: PCPresenceSubscription?, error: Error?)
+    case initialCursorsFetch(roomIdsToBasicCursors: [Int: PCBasicCursor]?, error: Error?)
+    case initialUsersFetch(users: [PCUser]?, error: Error?)
+}
+
+extension PCConnectionEventResult: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .userSubscriptionInit(_, let error), .presenceSubscriptionInit(_, let error),
+             .initialCursorsFetch(_, let error), .initialUsersFetch(_, let error):
+            return error == nil ? "non-nil value" : "\(error!.localizedDescription)"
+        }
+    }
+}
+
+public enum PCConnectionEventType: String {
+    case userSubscriptionInit
+    case presenceSubscriptionInit
+    case initialCursorsFetch
+    case initialUsersFetch
+}
+
+extension PCConnectionEventResult: Hashable {
+    public var hashValue: Int {
+        switch self {
+        case .userSubscriptionInit(_, _):
+            return 0
+        case .presenceSubscriptionInit(_, _):
+            return 1
+        case .initialCursorsFetch(_, _):
+            return 2
+        case .initialUsersFetch(_, _):
+            return 3
+        }
+    }
+
+    public static func ==(lhs: PCConnectionEventResult, rhs: PCConnectionEventResult) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+}

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -996,7 +996,7 @@ public final class PCCurrentUser {
         }
 
         let path = "/cursors/\(PCCursorType.read.rawValue)/rooms/\(roomId)/users/\(self.pathFriendlyId)"
-        let cursorRequest = PPRequestOptions(method: HTTPMethod.POST.rawValue, path: path, body: data)
+        let cursorRequest = PPRequestOptions(method: HTTPMethod.PUT.rawValue, path: path, body: data)
 
         self.cursorsInstance.request(
             using: cursorRequest,

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -786,12 +786,6 @@ public final class PCCurrentUser {
         )
     }
 
-    // TODO: Where should all the makeActiveRoom stuff live?
-
-    public func makeActiveRoom(_ room: PCRoom, delegate: PCRoomDelegate) {
-        self.subscribeToRoom(room: room, roomDelegate: delegate)
-    }
-
     // TODO: Do I need to add a Last-Event-ID option here?
     public func subscribeToRoom(room: PCRoom, roomDelegate: PCRoomDelegate, messageLimit: Int = 20) {
         let path = "/rooms/\(room.id)"

--- a/Sources/PCCursor.swift
+++ b/Sources/PCCursor.swift
@@ -1,0 +1,8 @@
+//
+//  PCCursor.swift
+//  PusherChatkit
+//
+//  Created by Hamilton Chapman on 30/01/2018.
+//
+
+import Foundation

--- a/Sources/PCCursor.swift
+++ b/Sources/PCCursor.swift
@@ -1,8 +1,37 @@
-//
-//  PCCursor.swift
-//  PusherChatkit
-//
-//  Created by Hamilton Chapman on 30/01/2018.
-//
-
 import Foundation
+
+public class PCCursor {
+    public let type: PCCursorType
+    public let position: Int
+    public let room: PCRoom
+    public let updatedAt: String
+    public let user: PCUser
+
+    public var updatedAtDate: Date { return self.dateFormatter.date(from: self.updatedAt)! }
+
+    private lazy var dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return dateFormatter
+    }()
+
+    init(
+        type: PCCursorType,
+        position: Int,
+        room: PCRoom,
+        updatedAt: String,
+        user: PCUser
+    ) {
+        self.type = type
+        self.position = position
+        self.room = room
+        self.updatedAt = updatedAt
+        self.user = user
+    }
+}
+
+extension PCCursor: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "Type: \(type.debugDescription), Position: \(position), Room: \(room.id), User: \(user.id), Updated At: \(updatedAt)"
+    }
+}

--- a/Sources/PCCursorSubscription.swift
+++ b/Sources/PCCursorSubscription.swift
@@ -1,8 +1,71 @@
-//
-//  PCCursorSubscription.swift
-//  PusherChatkit
-//
-//  Created by Hamilton Chapman on 30/01/2018.
-//
-
 import Foundation
+import PusherPlatform
+
+public final class PCCursorSubscription {
+    public var delegate: PCRoomDelegate?
+    let resumableSubscription: PPResumableSubscription
+    let basicCursorEnricher: PCBasicCursorEnricher
+    let handleCursorSet: (PCBasicCursor) -> Void
+    public var logger: PPLogger
+
+    init(
+        delegate: PCRoomDelegate? = nil,
+        resumableSubscription: PPResumableSubscription,
+        basicCursorEnricher: PCBasicCursorEnricher,
+        handleCursorSet: @escaping (PCBasicCursor) -> Void,
+        logger: PPLogger
+    ) {
+        self.delegate = delegate
+        self.resumableSubscription = resumableSubscription
+        self.basicCursorEnricher = basicCursorEnricher
+        self.handleCursorSet = handleCursorSet
+        self.logger = logger
+    }
+
+    func handleEvent(eventId _: String, headers _: [String: String], data: Any) {
+        guard let json = data as? [String: Any] else {
+            self.logger.log("Failed to cast JSON object to Dictionary: \(data)", logLevel: .debug)
+            return
+        }
+
+        guard let eventTypeName = json["event_name"] as? String else {
+            self.logger.log("Event type name missing from room subscription event: \(json)", logLevel: .debug)
+            return
+        }
+
+        let expectedEventTypeName = "cursor_set"
+
+        guard eventTypeName == expectedEventTypeName else {
+            self.logger.log("Expected event type name to be \(expectedEventTypeName) but got \(eventTypeName)", logLevel: .debug)
+            return
+        }
+
+        guard let basicCursorPayload = json["data"] as? [String: Any] else {
+            self.logger.log("Missing data for cursor subscription event: \(json)", logLevel: .debug)
+            return
+        }
+
+        do {
+            let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(basicCursorPayload)
+            self.handleCursorSet(basicCursor)
+
+            self.basicCursorEnricher.enrich(basicCursor) { [weak self] cursor, err in
+                guard let strongSelf = self else {
+                    print("self is nil when enrichment of basicCursor has completed")
+                    return
+                }
+
+                guard let cursor = cursor, err == nil else {
+                    strongSelf.logger.log(err!.localizedDescription, logLevel: .debug)
+                    return
+                }
+
+                strongSelf.delegate?.cursorSet(cursor: cursor)
+                strongSelf.logger.log("Cursor set: \(cursor.debugDescription)", logLevel: .verbose)
+            }
+        } catch let err {
+            self.logger.log(err.localizedDescription, logLevel: .debug)
+            // TODO: Should we call the delegate error func?
+        }
+    }
+}

--- a/Sources/PCCursorSubscription.swift
+++ b/Sources/PCCursorSubscription.swift
@@ -1,0 +1,8 @@
+//
+//  PCCursorSubscription.swift
+//  PusherChatkit
+//
+//  Created by Hamilton Chapman on 30/01/2018.
+//
+
+import Foundation

--- a/Sources/PCCursorType.swift
+++ b/Sources/PCCursorType.swift
@@ -1,0 +1,8 @@
+//
+//  PCCursorType.swift
+//  PusherChatkit
+//
+//  Created by Hamilton Chapman on 30/01/2018.
+//
+
+import Foundation

--- a/Sources/PCCursorType.swift
+++ b/Sources/PCCursorType.swift
@@ -1,8 +1,14 @@
-//
-//  PCCursorType.swift
-//  PusherChatkit
-//
-//  Created by Hamilton Chapman on 30/01/2018.
-//
-
 import Foundation
+
+public enum PCCursorType: Int {
+    case read
+}
+
+extension PCCursorType: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .read:
+            return "read"
+        }
+    }
+}

--- a/Sources/PCGlobalUserStore.swift
+++ b/Sources/PCGlobalUserStore.swift
@@ -178,6 +178,7 @@ public final class PCGlobalUserStore {
             },
             onError: { err in
                 self.instance.logger.log("Error fetching user information: \(err.localizedDescription)", logLevel: .debug)
+                completionHandler?(nil, err)
             }
         )
     }

--- a/Sources/PCPayloadDeserializer.swift
+++ b/Sources/PCPayloadDeserializer.swift
@@ -173,7 +173,7 @@ struct PCPayloadDeserializer {
         }
 
         return PCBasicCursor(
-            cursorType: cursorType,
+            type: cursorType,
             position: position,
             roomId: roomId,
             updatedAt: updatedAt,

--- a/Sources/PCRoom.swift
+++ b/Sources/PCRoom.swift
@@ -11,6 +11,18 @@ public final class PCRoom {
     public internal(set) var deletedAt: String?
 
     public internal(set) var subscription: PCRoomSubscription?
+    public internal(set) var cursorSubscription: PCCursorSubscription?
+
+    public internal(set) var currentUserCursor: PCBasicCursorState?
+
+    lazy var cursorSetHandler = { (cursor: PCBasicCursor, currentUserId: String) in
+        self.cursors[cursor.userId] = cursor
+        if cursor.userId == currentUserId {
+            self.currentUserCursor = .set(cursor)
+        }
+    }
+
+    public internal(set) var cursors: [String: PCBasicCursor] = [:]
 
     public internal(set) var userIds: Set<String>
 
@@ -71,7 +83,6 @@ public final class PCRoom {
 }
 
 extension PCRoom: Hashable {
-
     public var hashValue: Int {
         return self.id
     }
@@ -82,8 +93,23 @@ extension PCRoom: Hashable {
 }
 
 extension PCRoom: CustomDebugStringConvertible {
-
     public var debugDescription: String {
         return "ID: \(self.id) Name: \(self.name) Private: \(self.isPrivate)"
+    }
+}
+
+public enum PCBasicCursorState {
+    case unset
+    case set(PCBasicCursor)
+}
+
+extension PCBasicCursorState: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .unset:
+            return "No cursor has been set yet for the current user"
+        case .set(let basicCursor):
+            return "Cursor set with message ID: \(basicCursor.position), updated at: \(basicCursor.updatedAt)"
+        }
     }
 }

--- a/Sources/PCRoomDelegate.swift
+++ b/Sources/PCRoomDelegate.swift
@@ -13,6 +13,8 @@ public protocol PCRoomDelegate {
     func userCameOnlineInRoom(user: PCUser)
     func userWentOfflineInRoom(user: PCUser)
 
+    func cursorSet(cursor: PCCursor)
+
     // TODO: This seems like it could instead be `userListUpdated`, or something similar?
     func usersUpdated()
 
@@ -34,5 +36,6 @@ public extension PCRoomDelegate {
     func userLeft(user: PCUser) {}
     func userCameOnlineInRoom(user: PCUser) {}
     func userWentOfflineInRoom(user: PCUser) {}
+    func cursorSet(cursor: PCCursor) {}
     func usersUpdated() {}
 }

--- a/Sources/PCRoomSubscription.swift
+++ b/Sources/PCRoomSubscription.swift
@@ -43,7 +43,7 @@ public final class PCRoomSubscription {
         }
 
         do {
-            let basicMessage = try PCPayloadDeserializer.createMessageFromPayload(messagePayload)
+            let basicMessage = try PCPayloadDeserializer.createBasicMessageFromPayload(messagePayload)
 
             self.basicMessageEnricher.enrich(basicMessage) { [weak self] message, err in
                 guard let strongSelf = self else {


### PR DESCRIPTION
### What?

- Add cursors support
- Add connection coordinator; connection completion handler(s) are now only called when the following have completed:
   * User subscription has been established (or errored)
   * Presence subscription has been established (or errored)
   * Initial cursors fetch has completed (or errored)
   * Initial users fetch has completed (or errored)

### Why?

To add support for cursors and make connection behaviour more useful

----
CC @pusher/mobile