### PR TITLE
cursor_set -> new_cursor and associated renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Test target now works as expected
 
+## Changed
+
+- `cursorSet` renamed to `newCursor` in Room Delegate
+
 ## [0.6.3](https://github.com/pusher/chatkit-swift/compare/0.6.2...0.6.3) - 2018-02-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Test target now works as expected
 
-## Changed
+### Changed
 
-- `cursorSet` renamed to `newCursor` in Room Delegate
+- `cursorSet` renamed to `newCursor` in `PCRoomDelegate`
 
 ## [0.6.3](https://github.com/pusher/chatkit-swift/compare/0.6.2...0.6.3) - 2018-02-26
 

--- a/ChatkitiOSExample/ChatkitiOSExample/ViewController.swift
+++ b/ChatkitiOSExample/ChatkitiOSExample/ViewController.swift
@@ -132,8 +132,8 @@ extension ViewController: PCRoomDelegate {
         print(self.currentRoom!.users.map { "\($0.id), \($0.name!), \($0.presenceState.rawValue)" }.joined(separator: "; "))
     }
 
-    func cursorSet(cursor: PCCursor) {
-        print("Cursor set for \(cursor.user.displayName) at position \(cursor.position)")
+    func newCursor(cursor: PCCursor) {
+        print("New cursor for \(cursor.user.displayName) at position \(cursor.position)")
     }
 }
 

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -882,7 +882,7 @@ public final class PCCurrentUser {
             delegate: delegate,
             resumableSubscription: resumableSub,
             basicCursorEnricher: basicCursorEnricher,
-            handleCursorSet: { room.newCursorHandler($0, self.id) },
+            handleNewCursor: { room.newCursorHandler($0, self.id) },
             logger: self.cursorsInstance.logger
         )
 

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -882,7 +882,7 @@ public final class PCCurrentUser {
             delegate: delegate,
             resumableSubscription: resumableSub,
             basicCursorEnricher: basicCursorEnricher,
-            handleCursorSet: { room.cursorSetHandler($0, self.id) },
+            handleCursorSet: { room.newCursorHandler($0, self.id) },
             logger: self.cursorsInstance.logger
         )
 

--- a/Sources/PCCursorSubscription.swift
+++ b/Sources/PCCursorSubscription.swift
@@ -5,20 +5,20 @@ public final class PCCursorSubscription {
     public var delegate: PCRoomDelegate?
     let resumableSubscription: PPResumableSubscription
     let basicCursorEnricher: PCBasicCursorEnricher
-    let handleCursorSet: (PCBasicCursor) -> Void
+    let handleNewCursor: (PCBasicCursor) -> Void
     public var logger: PPLogger
 
     init(
         delegate: PCRoomDelegate? = nil,
         resumableSubscription: PPResumableSubscription,
         basicCursorEnricher: PCBasicCursorEnricher,
-        handleCursorSet: @escaping (PCBasicCursor) -> Void,
+        handleNewCursor: @escaping (PCBasicCursor) -> Void,
         logger: PPLogger
     ) {
         self.delegate = delegate
         self.resumableSubscription = resumableSubscription
         self.basicCursorEnricher = basicCursorEnricher
-        self.handleCursorSet = handleCursorSet
+        self.handleNewCursor = handleNewCursor
         self.logger = logger
     }
 
@@ -33,7 +33,7 @@ public final class PCCursorSubscription {
             return
         }
 
-        let expectedEventTypeName = "cursor_set"
+        let expectedEventTypeName = "new_cursor"
 
         guard eventTypeName == expectedEventTypeName else {
             self.logger.log("Expected event type name to be \(expectedEventTypeName) but got \(eventTypeName)", logLevel: .debug)
@@ -47,7 +47,7 @@ public final class PCCursorSubscription {
 
         do {
             let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(basicCursorPayload)
-            self.handleCursorSet(basicCursor)
+            self.handleNewCursor(basicCursor)
 
             self.basicCursorEnricher.enrich(basicCursor) { [weak self] cursor, err in
                 guard let strongSelf = self else {
@@ -60,8 +60,8 @@ public final class PCCursorSubscription {
                     return
                 }
 
-                strongSelf.delegate?.cursorSet(cursor: cursor)
-                strongSelf.logger.log("Cursor set: \(cursor.debugDescription)", logLevel: .verbose)
+                strongSelf.delegate?.newCursor(cursor: cursor)
+                strongSelf.logger.log("New cursor: \(cursor.debugDescription)", logLevel: .verbose)
             }
         } catch let err {
             self.logger.log(err.localizedDescription, logLevel: .debug)

--- a/Sources/PCRoom.swift
+++ b/Sources/PCRoom.swift
@@ -15,7 +15,7 @@ public final class PCRoom {
 
     public internal(set) var currentUserCursor: PCBasicCursorState?
 
-    lazy var cursorSetHandler = { (cursor: PCBasicCursor, currentUserId: String) in
+    lazy var newCursorHandler = { (cursor: PCBasicCursor, currentUserId: String) in
         self.cursors[cursor.userId] = cursor
         if cursor.userId == currentUserId {
             self.currentUserCursor = .set(cursor)

--- a/Sources/PCRoomDelegate.swift
+++ b/Sources/PCRoomDelegate.swift
@@ -13,7 +13,7 @@ public protocol PCRoomDelegate {
     func userCameOnlineInRoom(user: PCUser)
     func userWentOfflineInRoom(user: PCUser)
 
-    func cursorSet(cursor: PCCursor)
+    func newCursor(cursor: PCCursor)
 
     // TODO: This seems like it could instead be `userListUpdated`, or something similar?
     func usersUpdated()
@@ -36,6 +36,6 @@ public extension PCRoomDelegate {
     func userLeft(user: PCUser) {}
     func userCameOnlineInRoom(user: PCUser) {}
     func userWentOfflineInRoom(user: PCUser) {}
-    func cursorSet(cursor: PCCursor) {}
+    func newCursor(cursor: PCCursor) {}
     func usersUpdated() {}
 }


### PR DESCRIPTION
### What?

because `cursor_set` is being renamed to `new_cursor` asap

this isn't compiled or tested in any way

----

CC @hamchapman
