### PR TITLE
Cursor revamp and associated changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-swift/compare/0.6.4...HEAD)
 
+### Added
+
+`PCBaseClient` is added as a `typealias` for `PPBaseClient`
+
 ### Changed
 
+- `subscribeToRoom` will attempt to join the `PCCurrentUser` to the room if the user is not already a member
+- `PCRoom` no longer stores the cursors that relate to it; they are now all accessed using the `readCursor` function on `PCCurrentUser`, and the return type of this is `PCCursor?` (an optional `PCCursor`)
+- `PCCurrentUser`'s `setCursor` function has been renamed to `setReadCursor`
 - `cursorSet` renamed to `newCursor` in `PCRoomDelegate`
 - Bump PusherPlatform dependency to 0.4.2
 - `fetchToken` calls to `PCTokenProvider` are queued if there's an existing request underway
+
+### Removed
+
+- `ChatManager` no longer stores a reference to the `users` list, nor the `userSubscription`
+- `PCBasicCursorState` has been removed so now if you try to access the read cursors for a given `userId`-`roomId` combination you will either receive a `PCCursor` or `nil`
+- `currentUserCursor` has been removed from `PCRoom`; again, you'll instead need to use the `readCursor` function on `PCCurrentUser`
 
 ## [0.6.4](https://github.com/pusher/chatkit-swift/compare/0.6.3...0.6.4) - 2018-03-01
 

--- a/PusherChatkit.xcodeproj/project.pbxproj
+++ b/PusherChatkit.xcodeproj/project.pbxproj
@@ -21,8 +21,12 @@
 		334B9A2D1ECCA16A007A3D3B /* PCRoomStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334B9A2C1ECCA16A007A3D3B /* PCRoomStore.swift */; };
 		334B9A311ECD98A7007A3D3B /* PCBasicMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334B9A301ECD98A7007A3D3B /* PCBasicMessage.swift */; };
 		334B9A331ECD98FA007A3D3B /* PCBasicMessageEnricher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334B9A321ECD98FA007A3D3B /* PCBasicMessageEnricher.swift */; };
+		335AD5E6205828F7000D4D08 /* PCCursorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AD5E5205828F6000D4D08 /* PCCursorStore.swift */; };
+		335AD64E205982C1000D4D08 /* PCBasicCurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AD64D205982C1000D4D08 /* PCBasicCurrentUser.swift */; };
+		335AD8F8205C10AD000D4D08 /* PCMessageSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AD8F7205C10AD000D4D08 /* PCMessageSubscription.swift */; };
 		3361E7C12028753100F50580 /* PCConnectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3361E7C02028753100F50580 /* PCConnectionCoordinator.swift */; };
 		337C0C9620615A6600BB977A /* TokenProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337C0C9520615A6600BB977A /* TokenProviderTests.swift */; };
+		337C0B28205FFC7E00BB977A /* PCSharedInstanceOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337C0B27205FFC7E00BB977A /* PCSharedInstanceOptions.swift */; };
 		3388D5EF1EAE4DA90072A742 /* ChatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3388D5EE1EAE4DA90072A742 /* ChatManager.swift */; };
 		3388D5F11EAE4DD40072A742 /* PCChatManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3388D5F01EAE4DD40072A742 /* PCChatManagerDelegate.swift */; };
 		3388D5F31EAE4DFB0072A742 /* PCRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3388D5F21EAE4DFB0072A742 /* PCRoom.swift */; };
@@ -72,8 +76,12 @@
 		334B9A2C1ECCA16A007A3D3B /* PCRoomStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCRoomStore.swift; sourceTree = "<group>"; };
 		334B9A301ECD98A7007A3D3B /* PCBasicMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCBasicMessage.swift; sourceTree = "<group>"; };
 		334B9A321ECD98FA007A3D3B /* PCBasicMessageEnricher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PCBasicMessageEnricher.swift; sourceTree = "<group>"; };
+		335AD5E5205828F6000D4D08 /* PCCursorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCCursorStore.swift; sourceTree = "<group>"; };
+		335AD64D205982C1000D4D08 /* PCBasicCurrentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBasicCurrentUser.swift; sourceTree = "<group>"; };
+		335AD8F7205C10AD000D4D08 /* PCMessageSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMessageSubscription.swift; sourceTree = "<group>"; };
 		3361E7C02028753100F50580 /* PCConnectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCConnectionCoordinator.swift; sourceTree = "<group>"; };
 		337C0C9520615A6600BB977A /* TokenProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProviderTests.swift; sourceTree = "<group>"; };
+		337C0B27205FFC7E00BB977A /* PCSharedInstanceOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCSharedInstanceOptions.swift; sourceTree = "<group>"; };
 		33831C891A9CF61600B124F1 /* PusherChatkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PusherChatkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		33831C8D1A9CF61600B124F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		33831C941A9CF61600B124F1 /* PusherChatkitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PusherChatkitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -144,13 +152,16 @@
 			isa = PBXGroup;
 			children = (
 				3388D5EE1EAE4DA90072A742 /* ChatManager.swift */,
-				3361E7C02028753100F50580 /* PCConnectionCoordinator.swift */,
 				3388D5F61EAE4E330072A742 /* PCCurrentUser.swift */,
+				335AD64D205982C1000D4D08 /* PCBasicCurrentUser.swift */,
+				3361E7C02028753100F50580 /* PCConnectionCoordinator.swift */,
 				3388D5FC1EAE4EAC0072A742 /* PCUserSubscription.swift */,
 				331421341EDD8CDC00D0B6DB /* PCPresenceSubscription.swift */,
+				335AD8F7205C10AD000D4D08 /* PCMessageSubscription.swift */,
+				33C5D8F82020842200E826FB /* PCCursorSubscription.swift */,
+				3388D5FA1EAE4E640072A742 /* PCRoomSubscription.swift */,
 				3388D5F01EAE4DD40072A742 /* PCChatManagerDelegate.swift */,
 				3388D5F21EAE4DFB0072A742 /* PCRoom.swift */,
-				3388D5FA1EAE4E640072A742 /* PCRoomSubscription.swift */,
 				339CABD21EC3078200FDFB58 /* PCRoomDelegate.swift */,
 				3336C8161EE046F0005EB69A /* PCUserStoreCore.swift */,
 				334B9A2A1ECC9F7A007A3D3B /* PCGlobalUserStore.swift */,
@@ -166,7 +177,6 @@
 				331421321ED33C1400D0B6DB /* PCTypingIndicatorManager.swift */,
 				331F9BD81EBC80FA00C3F678 /* PCPayloadDeserializer.swift */,
 				3397D4C11EC2017000DD5994 /* PCSynchronizedArray.swift */,
-				33B3DD9E1EF7E2F60050CA02 /* PCTokenProvider.swift */,
 				33023E22200CB4A4001937C6 /* PCAttachment.swift */,
 				33BA563B200E634C00FFC587 /* PCAttachmentType.swift */,
 				33BA563D200E63DF00FFC587 /* PCFetchedAttachment.swift */,
@@ -174,8 +184,10 @@
 				33C5D8F4202082EB00E826FB /* PCBasicCursor.swift */,
 				33C5D8FA2020854A00E826FB /* PCCursor.swift */,
 				33C5D8F62020837100E826FB /* PCCursorType.swift */,
-				33C5D8F82020842200E826FB /* PCCursorSubscription.swift */,
 				33C5D8FC2020AA4C00E826FB /* PCBasicCursorEnricher.swift */,
+				335AD5E5205828F6000D4D08 /* PCCursorStore.swift */,
+				337C0B27205FFC7E00BB977A /* PCSharedInstanceOptions.swift */,
+				33B3DD9E1EF7E2F60050CA02 /* PCTokenProvider.swift */,
 				33E3EBC6200E2368003D888D /* PPTypealiases.swift */,
 				33831C8C1A9CF61600B124F1 /* Supporting Files */,
 				33346ABF1EAE1887002C58B8 /* PusherChatkit.h */,
@@ -357,14 +369,18 @@
 				331421351EDD8CDC00D0B6DB /* PCPresenceSubscription.swift in Sources */,
 				3336C8151EE045FE005EB69A /* PCRoomUserStore.swift in Sources */,
 				33C5D8FD2020AA4C00E826FB /* PCBasicCursorEnricher.swift in Sources */,
+				335AD64E205982C1000D4D08 /* PCBasicCurrentUser.swift in Sources */,
 				33023E23200CB4A4001937C6 /* PCAttachment.swift in Sources */,
 				334B9A2D1ECCA16A007A3D3B /* PCRoomStore.swift in Sources */,
 				3388D5F51EAE4E100072A742 /* PCMessage.swift in Sources */,
 				3388D5F71EAE4E330072A742 /* PCCurrentUser.swift in Sources */,
+				337C0B28205FFC7E00BB977A /* PCSharedInstanceOptions.swift in Sources */,
 				3388D5F11EAE4DD40072A742 /* PCChatManagerDelegate.swift in Sources */,
 				3388D5F31EAE4DFB0072A742 /* PCRoom.swift in Sources */,
 				33C5D8F72020837100E826FB /* PCCursorType.swift in Sources */,
+				335AD5E6205828F7000D4D08 /* PCCursorStore.swift in Sources */,
 				3314212F1ED32AE700D0B6DB /* PCProgressCounter.swift in Sources */,
+				335AD8F8205C10AD000D4D08 /* PCMessageSubscription.swift in Sources */,
 				33BA563E200E63DF00FFC587 /* PCFetchedAttachment.swift in Sources */,
 				339CABD31EC3078200FDFB58 /* PCRoomDelegate.swift in Sources */,
 				33C5D8FB2020854A00E826FB /* PCCursor.swift in Sources */,

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -10,73 +10,53 @@ import PusherPlatform
     public let userId: String
     public let pathFriendlyUserId: String
 
-    public internal(set) var userSubscription: PCUserSubscription?
-
-    public var currentUser: PCCurrentUser? {
-        return self.userSubscription?.currentUser
-    }
-
-    let userStore: PCGlobalUserStore
-
     let connectionCoordinator: PCConnectionCoordinator
-
-    // TODO: Do we need this here? Should it instead just live on the PCCurrentUser?
-    public var users: Set<PCUser> {
-        return self.userStore.users
-    }
+    var currentUser: PCCurrentUser?
 
     public init(
         instanceLocator: String,
         tokenProvider: PPTokenProvider,
         userId: String,
-        logger: PPLogger = PPDefaultLogger(),
-        baseClient: PPBaseClient? = nil
+        logger: PCLogger = PCDefaultLogger(),
+        baseClient: PCBaseClient? = nil
     ) {
         let splitInstance = instanceLocator.split(separator: ":")
         let cluster = splitInstance[1]
-        let sharedBaseClient = baseClient ?? PPBaseClient(host: "\(cluster).pusherplatform.io")
+        let sharedBaseClient = baseClient ?? PCBaseClient(host: "\(cluster).pusherplatform.io")
         sharedBaseClient.logger = logger
 
         let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "0.6.4")
 
-        self.instance = Instance(
+        let sharedInstanceOptions = PCSharedInstanceOptions(
             locator: instanceLocator,
+            sdkInfo: sdkInfo,
+            tokenProvider: tokenProvider,
+            baseClient: sharedBaseClient,
+            logger: logger
+        )
+
+        self.instance = ChatManager.createInstance(
             serviceName: "chatkit",
             serviceVersion: "v1",
-            sdkInfo: sdkInfo,
-            tokenProvider: tokenProvider,
-            client: baseClient,
-            logger: logger
+            sharedOptions: sharedInstanceOptions
         )
 
-        self.filesInstance = Instance(
-            locator: instanceLocator,
+        self.filesInstance = ChatManager.createInstance(
             serviceName: "chatkit_files",
             serviceVersion: "v1",
-            sdkInfo: sdkInfo,
-            tokenProvider: tokenProvider,
-            client: baseClient,
-            logger: logger
+            sharedOptions: sharedInstanceOptions
         )
 
-        self.cursorsInstance = Instance(
-            locator: instanceLocator,
+        self.cursorsInstance = ChatManager.createInstance(
             serviceName: "chatkit_cursors",
             serviceVersion: "v1",
-            sdkInfo: sdkInfo,
-            tokenProvider: tokenProvider,
-            client: baseClient,
-            logger: logger
+            sharedOptions: sharedInstanceOptions
         )
 
-        self.presenceInstance = Instance(
-            locator: instanceLocator,
+        self.presenceInstance = ChatManager.createInstance(
             serviceName: "chatkit_presence",
             serviceVersion: "v1",
-            sdkInfo: sdkInfo,
-            tokenProvider: tokenProvider,
-            client: baseClient,
-            logger: logger
+            sharedOptions: sharedInstanceOptions
         )
 
         self.connectionCoordinator = PCConnectionCoordinator(logger: logger)
@@ -85,7 +65,7 @@ import PusherPlatform
             tokenProvider.userId = userId
             tokenProvider.logger = logger
         }
-        self.userStore = PCGlobalUserStore(instance: self.instance)
+
         self.userId = userId
 
         let allowedCharacterSet = CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[] ").inverted
@@ -102,176 +82,225 @@ import PusherPlatform
         completionHandler: @escaping (PCCurrentUser?, Error?) -> Void
     ) {
         addConnectCompletionHandler(completionHandler: completionHandler)
+
+        let basicCurrentUser = PCBasicCurrentUser(
+            id: userId,
+            pathFriendlyId: pathFriendlyUserId,
+            instance: instance,
+            filesInstance: filesInstance,
+            cursorsInstance: cursorsInstance,
+            presenceInstance: presenceInstance,
+            connectionCoordinator: connectionCoordinator
+        )
+
+        // TODO: This could be nicer
         connectionCoordinator.connectionEventHandlers.append(
             PCConnectionEventHandler(
-                handler: { [weak self] events in
-                    guard let strongSelf = self else {
-                        print("self is nil when calling connection completion handler")
-                        return
-                    }
-
-                    guard events.count == 2 else {
-                        strongSelf.instance.logger.log(
-                            "Expected 2 events to be provided to connection event handler, but received \(events.count)",
-                            logLevel: .error
-                        )
-                        return
-                    }
-
-                    var currentUser: PCCurrentUser!
-                    var roomIdsToCursors: [Int: PCBasicCursor]!
-
+                handler: { events in
                     for event in events {
                         switch event.result {
-                        case .userSubscriptionInit(let curUser, let error):
-                            guard curUser != nil else {
-                                strongSelf.instance.logger.log(
-                                    "Error when getting current user object from connection event handler when about to set cursors: \(error!.localizedDescription)",
-                                    logLevel: .error
-                                )
-                                return
-                            }
-                            currentUser = curUser!
-                        case .initialCursorsFetch(let idsToCursors, let error):
-                            guard idsToCursors != nil else {
-                                strongSelf.instance.logger.log(
-                                    "Error when getting room ids to basic cursors object from connection event handler when about to set cursors: \(error!.localizedDescription)",
-                                    logLevel: .error
-                                )
-                                return
-                            }
-                            roomIdsToCursors = idsToCursors!
+                        case .userSubscriptionInit(let currentUser, _):
+                            currentUser?.userSubscription = basicCurrentUser.userSubscription
+                            currentUser?.presenceSubscription = basicCurrentUser.presenceSubscription
+                            currentUser?.cursorSubscription = basicCurrentUser.cursorSubscription
                         default:
                             break
                         }
                     }
-
-                    roomIdsToCursors.forEach { roomIdToCursor in
-                        guard let room = currentUser.rooms.first(where: { $0.id == roomIdToCursor.key }) else {
-                            strongSelf.instance.logger.log(
-                                "Received an initial cursor for room \(roomIdToCursor.key) but the current user object didn't know about the room",
-                                logLevel: .debug
-                            )
-                            return
-                        }
-                        strongSelf.instance.logger.log(
-                            "Setting current user's cursor: (\(roomIdToCursor.value), for room \(room.name)",
-                            logLevel: .verbose
-                        )
-                        room.currentUserCursor = .set(roomIdToCursor.value)
-                    }
-
-                    let roomIdsFromCursorsData = roomIdsToCursors.map { $0.key }
-                    currentUser.rooms.filter { !roomIdsFromCursorsData.contains($0.id) }.forEach {
-                        $0.currentUserCursor = .unset
-                    }
-
-                    // TODO: Does this stuff need to be done synchronously?
-                    currentUser.pendingRoomSubscriptions.forEach { roomSubInfo in
-                        strongSelf.instance.logger.log(
-                            "Processing pending room subscription for room: \(roomSubInfo.room.debugDescription)",
-                            logLevel: .verbose
-                        )
-                        if let messageLimit = roomSubInfo.messageLimit {
-                            currentUser.subscribeToRoom(
-                                room: roomSubInfo.room,
-                                roomDelegate: roomSubInfo.roomDelegate,
-                                messageLimit: messageLimit
-                            )
-                        } else {
-                            currentUser.subscribeToRoom(room: roomSubInfo.room, roomDelegate: roomSubInfo.roomDelegate)
-                        }
-                    }
-                    currentUser.pendingRoomSubscriptions = []
                 },
-                dependencies: [PCUserSubscriptionInitEvent, PCInitialCursorsFetchCompletedEvent]
+                dependencies: [
+                    PCUserSubscriptionInitEvent,
+                    PCPresenceSubscriptionInitEvent,
+                    PCCursorSubscriptionInitEvent
+                ]
             )
         )
 
-        let path = "/users"
-        let subscribeRequest = PPRequestOptions(method: HTTPMethod.SUBSCRIBE.rawValue, path: path)
-
-        var resumableSub = PPResumableSubscription(
-            instance: self.instance,
-            requestOptions: subscribeRequest
-        )
-
-        self.userSubscription = PCUserSubscription(
-            instance: self.instance,
-            filesInstance: self.filesInstance,
-            cursorsInstance: self.cursorsInstance,
-            presenceInstance: self.presenceInstance,
-            resumableSubscription: resumableSub,
-            userStore: self.userStore,
+        basicCurrentUser.establishUserSubscription(
             delegate: delegate,
-            userId: userId,
-            pathFriendlyUserId: pathFriendlyUserId,
-            connectionCoordinator: connectionCoordinator
-        )
+            initialStateHandler: { currentUserPayloadTuple in
+                let (roomsPayload, currentUserPayload) = currentUserPayloadTuple
 
-        // TODO: Decide what to do with onEnd
-        self.instance.subscribeWithResume(
-            with: &resumableSub,
-            using: subscribeRequest,
-            onEvent: self.userSubscription!.handleEvent,
-            onEnd: { _, _, _ in },
-            onError: { error in
-                self.connectionCoordinator.connectionEventCompleted(PCConnectionEvent(currentUser: nil, error: error))
-            }
-        )
+                let receivedCurrentUser: PCCurrentUser
 
-        let getCursorsPath = "/cursors/\(PCCursorType.read.rawValue)/users/\(self.pathFriendlyUserId)"
-        let cursorsRequestOptions = PPRequestOptions(method: HTTPMethod.GET.rawValue, path: getCursorsPath)
-
-        self.cursorsInstance.requestWithRetry(
-            using: cursorsRequestOptions,
-            onSuccess: { data in
-                guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                    self.connectionCoordinator.connectionEventCompleted(
-                        PCConnectionEvent(roomIdsToBasicCursors: nil, error: PCError.failedToDeserializeJSON(data))
+                do {
+                    receivedCurrentUser = try PCPayloadDeserializer.createCurrentUserFromPayload(
+                        currentUserPayload,
+                        id: self.userId,
+                        pathFriendlyId: self.pathFriendlyUserId,
+                        instance: self.instance,
+                        filesInstance: self.filesInstance,
+                        cursorsInstance: self.cursorsInstance,
+                        presenceInstance: self.presenceInstance,
+                        userStore: basicCurrentUser.userStore,
+                        roomStore: basicCurrentUser.roomStore,
+                        cursorStore: basicCurrentUser.cursorStore,
+                        connectionCoordinator: self.connectionCoordinator
+                    )
+                } catch let err {
+                    self.informConnectionCoordinatorOfCurrentUserCompletion(
+                        currentUser: nil,
+                        error: err
                     )
                     return
                 }
 
-                guard let cursorsPayload = jsonObject as? [[String: Any]] else {
-                    self.connectionCoordinator.connectionEventCompleted(
-                        PCConnectionEvent(roomIdsToBasicCursors: nil, error: PCError.failedToCastJSONObjectToDictionary(jsonObject))
-                    )
+                // If the currentUser property is already set then the assumption is that there was
+                // already a user subscription and so instead of setting the property to a new
+                // PCCurrentUser, we update the existing one to have the most up-to-date state
+                if let currentUser = self.currentUser {
+                    currentUser.updateWithPropertiesOf(receivedCurrentUser)
+                } else {
+                    self.currentUser = receivedCurrentUser
+                }
+
+                guard roomsPayload.count > 0 else {
+                    self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
+                    // There are no users to fetch information about so we are safe to inform
+                    // the connection coordinator of a success immediately
+                    self.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: [], error: nil)
                     return
                 }
 
-                var roomIdsToBasicCursors: [Int: PCBasicCursor] = [:]
-                cursorsPayload.forEach { cursorPayload in
+                let roomsAddedToRoomStoreProgressCounter = PCProgressCounter(
+                    totalCount: roomsPayload.count,
+                    labelSuffix: "roomstore-room-append"
+                )
+
+                var combinedRoomUserIds = Set<String>()
+                var roomsFromConnection = [PCRoom]()
+
+                roomsPayload.forEach { roomPayload in
                     do {
-                        let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(cursorPayload)
-                        roomIdsToBasicCursors[basicCursor.roomId] = basicCursor
+                        let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
+
+                        combinedRoomUserIds.formUnion(room.userIds)
+                        roomsFromConnection.append(room)
+
+                        self.currentUser!.roomStore.addOrMerge(room) { _ in
+                            if roomsAddedToRoomStoreProgressCounter.incrementSuccessAndCheckIfFinished() {
+                                self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
+                                self.fetchInitialUserInformationForUserIds(
+                                    combinedRoomUserIds,
+                                    userStore: basicCurrentUser.userStore,
+                                    roomStore: basicCurrentUser.roomStore
+                                )
+                            }
+                        }
                     } catch let err {
-                        self.instance.logger.log(err.localizedDescription, logLevel: .debug)
+                        self.instance.logger.log(
+                            "Incomplete room payload in initial_state event: \(roomPayload). Error: \(err.localizedDescription)",
+                            logLevel: .debug
+                        )
+                        if roomsAddedToRoomStoreProgressCounter.incrementFailedAndCheckIfFinished() {
+                            self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
+                            self.fetchInitialUserInformationForUserIds(
+                                combinedRoomUserIds,
+                               userStore: basicCurrentUser.userStore,
+                               roomStore: basicCurrentUser.roomStore
+                            )
+                        }
                     }
                 }
-
-                self.connectionCoordinator.connectionEventCompleted(
-                    PCConnectionEvent(roomIdsToBasicCursors: roomIdsToBasicCursors, error: nil)
-                )
-            },
-            onError: { err in
-                self.instance.logger.log("Error fetching initial cursors for user: \(err.localizedDescription)", logLevel: .debug)
-                self.connectionCoordinator.connectionEventCompleted(
-                    PCConnectionEvent(roomIdsToBasicCursors: nil, error: err)
-                )
             }
         )
+
+        basicCurrentUser.establishPresenceSubscription(delegate: delegate)
+        basicCurrentUser.establishCursorSubscription()
     }
 
     // TODO: Maybe we need some sort of ChatManagerConnectionState?
-
     public func disconnect() {
-        // End all subscriptions
-        userSubscription?.resumableSubscription.end()
+        currentUser?.userSubscription?.end()
         currentUser?.presenceSubscription?.end()
+        currentUser?.cursorSubscription?.end()
         currentUser?.rooms.forEach { room in
-            room.subscription?.resumableSubscription.end()
+            room.subscription?.end()
         }
         connectionCoordinator.reset()
+    }
+
+    fileprivate static func createInstance(
+        serviceName: String,
+        serviceVersion: String,
+        sharedOptions options: PCSharedInstanceOptions
+    ) -> Instance {
+        return Instance(
+            locator: options.locator,
+            serviceName: serviceName,
+            serviceVersion: serviceVersion,
+            sdkInfo: options.sdkInfo,
+            tokenProvider: options.tokenProvider,
+            client: options.baseClient,
+            logger: options.logger
+        )
+    }
+
+    fileprivate func fetchInitialUserInformationForUserIds(
+        _ userIds: Set<String>,
+        userStore: PCGlobalUserStore,
+        roomStore: PCRoomStore
+    ) {
+        userStore.initialFetchOfUsersWithIds(userIds) { users, err in
+            guard err == nil else {
+                self.instance.logger.log(
+                    "Unable to fetch user information after successful connection: \(err!.localizedDescription)",
+                    logLevel: .debug
+                )
+                self.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: nil, error: err!)
+                return
+            }
+
+            let combinedRoomUsersProgressCounter = PCProgressCounter(totalCount: roomStore.rooms.count, labelSuffix: "room-users-combined")
+
+            // TODO: This could be a lot more efficient
+            roomStore.rooms.forEach { room in
+                let roomUsersProgressCounter = PCProgressCounter(totalCount: room.userIds.count, labelSuffix: "room-users")
+
+                room.userIds.forEach { userId in
+                    userStore.user(id: userId) { [weak self] user, err in
+                        guard let strongSelf = self else {
+                            print("self is nil when user store returns user after initial fetch of users")
+                            return
+                        }
+
+                        guard let user = user, err == nil else {
+                            strongSelf.instance.logger.log(
+                                "Unable to add user with id \(userId) to room \(room.name): \(err!.localizedDescription)",
+                                logLevel: .debug
+                            )
+                            if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
+                                room.subscription?.delegate?.usersUpdated()
+                                strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
+
+                                if combinedRoomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
+                                    strongSelf.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: nil, error: err!)
+                                }
+                            }
+                            return
+                        }
+
+                        room.userStore.addOrMerge(user)
+
+                        if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
+                            room.subscription?.delegate?.usersUpdated()
+                            strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
+
+                            if combinedRoomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
+                                strongSelf.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: users, error: nil)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fileprivate func informConnectionCoordinatorOfCurrentUserCompletion(currentUser: PCCurrentUser?, error: Error?) {
+        connectionCoordinator.connectionEventCompleted(PCConnectionEvent(currentUser: currentUser, error: error))
+    }
+
+    fileprivate func informConnectionCoordinatorOfInitialUsersFetchCompletion(users: [PCUser]?, error: Error?) {
+        connectionCoordinator.connectionEventCompleted(PCConnectionEvent(users: users, error: error))
     }
 }

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -168,22 +168,20 @@ import PusherPlatform
                 )
 
                 var combinedRoomUserIds = Set<String>()
-                var roomsFromConnection = [PCRoom]()
 
                 roomsPayload.forEach { roomPayload in
                     do {
                         let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
 
                         combinedRoomUserIds.formUnion(room.userIds)
-                        roomsFromConnection.append(room)
 
                         self.currentUser!.roomStore.addOrMerge(room) { _ in
                             if roomsAddedToRoomStoreProgressCounter.incrementSuccessAndCheckIfFinished() {
                                 self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
                                 self.fetchInitialUserInformationForUserIds(
                                     combinedRoomUserIds,
-                                    userStore: basicCurrentUser.userStore,
-                                    roomStore: basicCurrentUser.roomStore
+                                    userStore: self.currentUser!.userStore,
+                                    roomStore: self.currentUser!.roomStore
                                 )
                             }
                         }
@@ -196,8 +194,8 @@ import PusherPlatform
                             self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
                             self.fetchInitialUserInformationForUserIds(
                                 combinedRoomUserIds,
-                               userStore: basicCurrentUser.userStore,
-                               roomStore: basicCurrentUser.roomStore
+                               userStore: self.currentUser!.userStore,
+                               roomStore: self.currentUser!.roomStore
                             )
                         }
                     }
@@ -270,7 +268,7 @@ import PusherPlatform
                                 logLevel: .debug
                             )
                             if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                                room.subscription?.delegate?.usersUpdated()
+                                room.subscription?.delegate.usersUpdated()
                                 strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
 
                                 if combinedRoomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
@@ -283,7 +281,7 @@ import PusherPlatform
                         room.userStore.addOrMerge(user)
 
                         if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                            room.subscription?.delegate?.usersUpdated()
+                            room.subscription?.delegate.usersUpdated()
                             strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
 
                             if combinedRoomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {

--- a/Sources/PCBasicCurrentUser.swift
+++ b/Sources/PCBasicCurrentUser.swift
@@ -1,0 +1,170 @@
+import Foundation
+import PusherPlatform
+
+public final class PCBasicCurrentUser {
+    public let id: String
+    public let pathFriendlyId: String
+
+    let userStore: PCGlobalUserStore
+    let roomStore: PCRoomStore
+    let cursorStore: PCCursorStore
+
+    public internal(set) var userSubscription: PCUserSubscription?
+    public internal(set) var presenceSubscription: PCPresenceSubscription?
+    public internal(set) var cursorSubscription: PCCursorSubscription?
+
+    let instance: Instance
+    let filesInstance: Instance
+    let cursorsInstance: Instance
+    let presenceInstance: Instance
+
+    let connectionCoordinator: PCConnectionCoordinator
+
+    public init(
+        id: String,
+        pathFriendlyId: String,
+        instance: Instance,
+        filesInstance: Instance,
+        cursorsInstance: Instance,
+        presenceInstance: Instance,
+        connectionCoordinator: PCConnectionCoordinator
+    ) {
+        self.id = id
+        self.pathFriendlyId = pathFriendlyId
+        self.instance = instance
+        self.filesInstance = filesInstance
+        self.cursorsInstance = cursorsInstance
+        self.presenceInstance = presenceInstance
+        self.connectionCoordinator = connectionCoordinator
+
+        let rooms = PCSynchronizedArray<PCRoom>()
+        self.userStore = PCGlobalUserStore(instance: instance)
+        self.roomStore = PCRoomStore(rooms: rooms, instance: instance)
+        self.cursorStore = PCCursorStore(
+            instance: instance,
+            roomStore: roomStore,
+            userStore: userStore
+        )
+    }
+
+    func establishUserSubscription(
+        delegate: PCChatManagerDelegate,
+        initialStateHandler: @escaping ((roomsPayload: [[String: Any]], currentUserPayload: [String: Any])) -> Void
+    ) {
+        let path = "/users"
+        let subscribeRequest = PPRequestOptions(method: HTTPMethod.SUBSCRIBE.rawValue, path: path)
+
+        var resumableSub = PPResumableSubscription(
+            instance: self.instance,
+            requestOptions: subscribeRequest
+        )
+
+        self.userSubscription = PCUserSubscription(
+            instance: self.instance,
+            filesInstance: self.filesInstance,
+            cursorsInstance: self.cursorsInstance,
+            presenceInstance: self.presenceInstance,
+            resumableSubscription: resumableSub,
+            userStore: self.userStore,
+            delegate: delegate,
+            userId: id,
+            pathFriendlyUserId: pathFriendlyId,
+            connectionCoordinator: connectionCoordinator,
+            initialStateHandler: initialStateHandler
+        )
+
+        // TODO: Decide what to do with onEnd
+        self.instance.subscribeWithResume(
+            with: &resumableSub,
+            using: subscribeRequest,
+            onEvent: self.userSubscription!.handleEvent,
+            onEnd: { _, _, _ in },
+            onError: { error in
+                self.connectionCoordinator.connectionEventCompleted(
+                    PCConnectionEvent(currentUser: nil, error: error)
+                )
+            }
+        )
+    }
+
+    func establishPresenceSubscription(delegate: PCChatManagerDelegate) {
+        // If a presenceSubscription already exists then we want to create a new one
+        // to ensure that the most up-to-date state is received, so we first close the
+        // existing subscription, if it was still open
+        if let presSub = self.presenceSubscription {
+            presSub.end()
+            self.presenceSubscription = nil
+        }
+
+        let path = "/users/\(self.pathFriendlyId)/presence"
+        let subscribeRequest = PPRequestOptions(method: HTTPMethod.SUBSCRIBE.rawValue, path: path)
+
+        var resumableSub = PPResumableSubscription(
+            instance: self.presenceInstance,
+            requestOptions: subscribeRequest
+        )
+
+        self.presenceSubscription = PCPresenceSubscription(
+            instance: self.presenceInstance,
+            resumableSubscription: resumableSub,
+            userStore: self.userStore,
+            roomStore: self.roomStore,
+            connectionCoordinator: self.connectionCoordinator,
+            delegate: delegate
+        )
+
+        self.presenceInstance.subscribeWithResume(
+            with: &resumableSub,
+            using: subscribeRequest,
+            onEvent: self.presenceSubscription!.handleEvent,
+            onError: { error in
+                self.connectionCoordinator.connectionEventCompleted(
+                    PCConnectionEvent(presenceSubscription: nil, error: error)
+                )
+            }
+        )
+    }
+
+    func establishCursorSubscription() {
+        let userCursorSubscriptionPath = "/cursors/\(PCCursorType.read.rawValue)/users/\(self.pathFriendlyId)"
+        let cursorSubscriptionRequestOptions = PPRequestOptions(
+            method: HTTPMethod.SUBSCRIBE.rawValue,
+            path: userCursorSubscriptionPath
+        )
+
+        var cursorResumableSub = PPResumableSubscription(
+            instance: self.cursorsInstance,
+            requestOptions: cursorSubscriptionRequestOptions
+        )
+
+        self.cursorSubscription = PCCursorSubscription(
+            resumableSubscription: cursorResumableSub,
+            cursorStore: cursorStore,
+            connectionCoordinator: self.connectionCoordinator,
+            logger: self.cursorsInstance.logger,
+            initialStateHandler: { err in
+                if let err = err {
+                    self.cursorsInstance.logger.log(err.localizedDescription, logLevel: .debug)
+                }
+                // TODO: Should the connection coordinator get the error here?
+                // Do we care if a single (in this weird case, only the last to be received)
+                // basic cursor can't be enriched with information about its room and/or user?
+                // We probably just want to log something
+                self.connectionCoordinator.connectionEventCompleted(
+                    PCConnectionEvent(cursorSubscription: self.cursorSubscription, error: nil)
+                )
+            }
+        )
+
+        self.cursorsInstance.subscribeWithResume(
+            with: &cursorResumableSub,
+            using: cursorSubscriptionRequestOptions,
+            onEvent: self.cursorSubscription!.handleEvent,
+            onError: { error in
+                self.connectionCoordinator.connectionEventCompleted(
+                    PCConnectionEvent(cursorSubscription: nil, error: error)
+                )
+            }
+        )
+    }
+}

--- a/Sources/PCBasicCursorEnricher.swift
+++ b/Sources/PCBasicCursorEnricher.swift
@@ -3,40 +3,56 @@ import PusherPlatform
 
 final class PCBasicCursorEnricher {
     public let userStore: PCGlobalUserStore
-    public let room: PCRoom
+    public let roomStore: PCRoomStore
     let logger: PPLogger
 
-    init(userStore: PCGlobalUserStore, room: PCRoom, logger: PPLogger) {
+    init(userStore: PCGlobalUserStore, roomStore: PCRoomStore, logger: PPLogger) {
         self.userStore = userStore
-        self.room = room
+        self.roomStore = roomStore
         self.logger = logger
     }
 
     func enrich(_ basicCursor: PCBasicCursor, completionHandler: @escaping (PCCursor?, Error?) -> Void) {
-        self.userStore.user(id: basicCursor.userId) { [weak self] user, err in
+        self.userStore.user(id: basicCursor.userId) { [weak self] user, userErr in
             guard let strongSelf = self else {
                 print("self is nil when user store returns user while enriching cursor")
                 return
             }
 
-            guard let user = user, err == nil else {
+            guard let user = user, userErr == nil else {
                 strongSelf.logger.log(
-                    "Unable to find user with id \(basicCursor.userId) while enriching cursor. Error: \(err!.localizedDescription)",
+                    "Unable to find user with id \(basicCursor.userId) while enriching cursor. Error: \(userErr!.localizedDescription)",
                     logLevel: .debug
                 )
-                completionHandler(nil, err!)
+                completionHandler(nil, userErr!)
                 return
             }
 
-            let cursor = PCCursor(
-                type: basicCursor.type,
-                position: basicCursor.position,
-                room: strongSelf.room,
-                updatedAt: basicCursor.updatedAt,
-                user: user
-            )
+            strongSelf.roomStore.room(id: basicCursor.roomId) { [weak self] room, roomErr in
+                guard let strongSelf = self else {
+                    print("self is nil when room store returns room while enriching cursor")
+                    return
+                }
 
-            completionHandler(cursor, nil)
+                guard let room = room, roomErr == nil else {
+                    strongSelf.logger.log(
+                        "Unable to find user with id \(basicCursor.userId) while enriching cursor. Error: \(roomErr!.localizedDescription)",
+                        logLevel: .debug
+                    )
+                    completionHandler(nil, roomErr!)
+                    return
+                }
+
+                let cursor = PCCursor(
+                    type: basicCursor.type,
+                    position: basicCursor.position,
+                    room: room,
+                    updatedAt: basicCursor.updatedAt,
+                    user: user
+                )
+
+                completionHandler(cursor, nil)
+            }
         }
     }
 }

--- a/Sources/PCConnectionCoordinator.swift
+++ b/Sources/PCConnectionCoordinator.swift
@@ -102,8 +102,8 @@ public class PCConnectionEvent {
         self.init(type: .presenceSubscriptionInit, result: .presenceSubscriptionInit(presenceSubscription: presenceSubscription, error: error))
     }
 
-    convenience init(roomIdsToBasicCursors: [Int: PCBasicCursor]?, error: Error?) {
-        self.init(type: .initialCursorsFetch, result: .initialCursorsFetch(roomIdsToBasicCursors: roomIdsToBasicCursors, error: error))
+    convenience init(cursorSubscription: PCCursorSubscription?, error: Error?) {
+        self.init(type: .cursorSubscriptionInit, result: .cursorSubscriptionInit(cursorSubscription: cursorSubscription, error: error))
     }
 
     convenience init(users: [PCUser]?, error: Error?) {
@@ -118,8 +118,8 @@ public class PCConnectionEvent {
         return PCConnectionEvent(type: .presenceSubscriptionInit, result: .presenceSubscriptionInit(presenceSubscription: nil, error: nil))
     }
 
-    fileprivate static func initialCursorsFetchCompleted() -> PCConnectionEvent {
-        return PCConnectionEvent(type: .initialCursorsFetch, result: .initialCursorsFetch(roomIdsToBasicCursors: nil, error: nil))
+    fileprivate static func cursorSubscriptionInit() -> PCConnectionEvent {
+        return PCConnectionEvent(type: .cursorSubscriptionInit, result: .cursorSubscriptionInit(cursorSubscription: nil, error: nil))
     }
 
     fileprivate static func initialUsersFetchCompleted() -> PCConnectionEvent {
@@ -135,13 +135,13 @@ extension PCConnectionEvent: CustomDebugStringConvertible {
 
 public let PCUserSubscriptionInitEvent = PCConnectionEvent.userSubscriptionInit()
 public let PCPresenceSubscriptionInitEvent = PCConnectionEvent.presenceSubscriptionInit()
-public let PCInitialCursorsFetchCompletedEvent = PCConnectionEvent.initialCursorsFetchCompleted()
+public let PCCursorSubscriptionInitEvent = PCConnectionEvent.cursorSubscriptionInit()
 public let PCInitialUsersFetchCompletedEvent = PCConnectionEvent.initialUsersFetchCompleted()
 
 fileprivate let allConnectionEvents: Set<PCConnectionEvent> = [
     PCUserSubscriptionInitEvent,
     PCPresenceSubscriptionInitEvent,
-    PCInitialCursorsFetchCompletedEvent,
+    PCCursorSubscriptionInitEvent,
     PCInitialUsersFetchCompletedEvent
 ]
 
@@ -158,7 +158,7 @@ extension PCConnectionEvent: Hashable {
 public enum PCConnectionEventResult {
     case userSubscriptionInit(currentUser: PCCurrentUser?, error: Error?)
     case presenceSubscriptionInit(presenceSubscription: PCPresenceSubscription?, error: Error?)
-    case initialCursorsFetch(roomIdsToBasicCursors: [Int: PCBasicCursor]?, error: Error?)
+    case cursorSubscriptionInit(cursorSubscription: PCCursorSubscription?, error: Error?)
     case initialUsersFetch(users: [PCUser]?, error: Error?)
 }
 
@@ -166,8 +166,8 @@ extension PCConnectionEventResult: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .userSubscriptionInit(_, let error), .presenceSubscriptionInit(_, let error),
-             .initialCursorsFetch(_, let error), .initialUsersFetch(_, let error):
-            return error == nil ? "non-nil value" : "\(error!.localizedDescription)"
+             .cursorSubscriptionInit(_, let error), .initialUsersFetch(_, let error):
+            return error == nil ? "success" : "\(error!.localizedDescription)"
         }
     }
 }
@@ -175,7 +175,7 @@ extension PCConnectionEventResult: CustomDebugStringConvertible {
 public enum PCConnectionEventType: String {
     case userSubscriptionInit
     case presenceSubscriptionInit
-    case initialCursorsFetch
+    case cursorSubscriptionInit
     case initialUsersFetch
 }
 
@@ -186,7 +186,7 @@ extension PCConnectionEventResult: Hashable {
             return 0
         case .presenceSubscriptionInit(_, _):
             return 1
-        case .initialCursorsFetch(_, _):
+        case .cursorSubscriptionInit(_, _):
             return 2
         case .initialUsersFetch(_, _):
             return 3

--- a/Sources/PCConnectionCoordinator.swift
+++ b/Sources/PCConnectionCoordinator.swift
@@ -78,7 +78,10 @@ public class PCConnectionEventHandler {
     public let handler: ([PCConnectionEvent]) -> Void
     public let dependencies: Set<PCConnectionEvent>
 
-    public init(handler: @escaping ([PCConnectionEvent]) -> Void, dependencies: Set<PCConnectionEvent>) {
+    public init(
+        handler: @escaping ([PCConnectionEvent]) -> Void,
+        dependencies: Set<PCConnectionEvent>
+    ) {
         self.handler = handler
         self.dependencies = dependencies
     }

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -382,7 +382,7 @@ public final class PCCurrentUser {
                     )
 
                     if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                        room.subscription?.delegate?.usersUpdated()
+                        room.subscription?.delegate.usersUpdated()
                         strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                     }
 
@@ -392,7 +392,7 @@ public final class PCCurrentUser {
                 room.userStore.addOrMerge(user)
 
                 if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                    room.subscription?.delegate?.usersUpdated()
+                    room.subscription?.delegate.usersUpdated()
                     strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                 }
             }
@@ -806,7 +806,8 @@ public final class PCCurrentUser {
 
             room.subscription = PCRoomSubscription(
                 messageSubscription: messageSub,
-                cursorSubscription: cursorSub
+                cursorSubscription: cursorSub,
+                delegate: roomDelegate
             )
         }
     }

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -11,6 +11,7 @@ public final class PCCurrentUser {
 
     let userStore: PCGlobalUserStore
     let roomStore: PCRoomStore
+    let cursorStore: PCCursorStore
 
     public typealias ErrorCompletionHandler = (Error?) -> Void
     public typealias RoomCompletionHandler = (PCRoom?, Error?) -> Void
@@ -28,7 +29,9 @@ public final class PCCurrentUser {
 
     public let pathFriendlyId: String
 
+    public internal(set) var userSubscription: PCUserSubscription?
     public internal(set) var presenceSubscription: PCPresenceSubscription?
+    public internal(set) var cursorSubscription: PCCursorSubscription?
 
     var typingIndicatorManagers: [Int: PCTypingIndicatorManager] = [:]
     private var typingIndicatorQueue = DispatchQueue(label: "com.pusher.chatkit.typing-indicators")
@@ -39,7 +42,6 @@ public final class PCCurrentUser {
     let presenceInstance: Instance
 
     let connectionCoordinator: PCConnectionCoordinator
-    var pendingRoomSubscriptions: [(room: PCRoom, roomDelegate: PCRoomDelegate, messageLimit: Int?)] = []
 
     private lazy var dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
@@ -58,12 +60,13 @@ public final class PCCurrentUser {
         name: String?,
         avatarURL: String?,
         customData: [String: Any]?,
-        rooms: PCSynchronizedArray<PCRoom> = PCSynchronizedArray<PCRoom>(),
         instance: Instance,
         filesInstance: Instance,
         cursorsInstance: Instance,
         presenceInstance: Instance,
         userStore: PCGlobalUserStore,
+        roomStore: PCRoomStore,
+        cursorStore: PCCursorStore,
         connectionCoordinator: PCConnectionCoordinator
     ) {
         self.id = id
@@ -73,12 +76,13 @@ public final class PCCurrentUser {
         self.name = name
         self.avatarURL = avatarURL
         self.customData = customData
-        self.roomStore = PCRoomStore(rooms: rooms, instance: instance)
         self.instance = instance
         self.filesInstance = filesInstance
         self.cursorsInstance = cursorsInstance
         self.presenceInstance = presenceInstance
         self.userStore = userStore
+        self.roomStore = roomStore
+        self.cursorStore = cursorStore
         self.connectionCoordinator = connectionCoordinator
     }
 
@@ -86,40 +90,6 @@ public final class PCCurrentUser {
         self.updatedAt = currentUser.updatedAt
         self.name = currentUser.name
         self.customData = currentUser.customData
-    }
-
-    func setupPresenceSubscription(delegate: PCChatManagerDelegate) {
-        // If a presenceSubscription already exists then we want to create a new one
-        // to ensure that the most up-to-date state is received, so we first close the
-        // existing subscription, if it was still open
-        if let presSub = self.presenceSubscription {
-            presSub.end()
-            self.presenceSubscription = nil
-        }
-
-        let path = "/users/\(self.id)/presence"
-
-        let subscribeRequest = PPRequestOptions(method: HTTPMethod.SUBSCRIBE.rawValue, path: path)
-
-        var resumableSub = PPResumableSubscription(
-            instance: self.presenceInstance,
-            requestOptions: subscribeRequest
-        )
-
-        self.presenceSubscription = PCPresenceSubscription(
-            instance: self.presenceInstance,
-            resumableSubscription: resumableSub,
-            userStore: self.userStore,
-            roomStore: self.roomStore,
-            connectionCoordinator: self.connectionCoordinator,
-            delegate: delegate
-        )
-
-        self.presenceInstance.subscribeWithResume(
-            with: &resumableSub,
-            using: subscribeRequest,
-            onEvent: self.presenceSubscription!.handleEvent
-        )
     }
 
     public func createRoom(
@@ -355,6 +325,11 @@ public final class PCCurrentUser {
     }
 
     fileprivate func joinRoom(roomId: Int, completionHandler: @escaping RoomCompletionHandler) {
+        if let room = self.rooms.first(where: { $0.id == roomId }) {
+            completionHandler(room, nil)
+            return
+        }
+
         let path = "/users/\(self.pathFriendlyId)/rooms/\(roomId)/join"
         let generalRequest = PPRequestOptions(method: HTTPMethod.POST.rawValue, path: path)
 
@@ -805,22 +780,42 @@ public final class PCCurrentUser {
 
     // TODO: Do I need to add a Last-Event-ID option here?
     public func subscribeToRoom(room: PCRoom, roomDelegate: PCRoomDelegate, messageLimit: Int = 20) {
-        guard room.currentUserCursor != nil else {
-            // We only get here if the initial cursor fetch hasn't completed yet and so
-            // the currentUserCursor prop for the room is nil (not .unset or .set)
-            pendingRoomSubscriptions.append((room: room, roomDelegate: roomDelegate, messageLimit: messageLimit))
-            self.instance.logger.log(
-                "Room subscription waiting to begin until current user's room cursor has been received",
-                logLevel: .verbose
-            )
-            return
-        }
-
         self.instance.logger.log(
             "About to subscribe to room \(room.debugDescription)",
             logLevel: .verbose
         )
 
+        self.joinRoom(roomId: room.id) { innerRoom, err in
+            guard let roomToSubscribeTo = innerRoom, err == nil else {
+                self.instance.logger.log(
+                    "Error joining room as part of room subscription process \(room.debugDescription)",
+                    logLevel: .error
+                )
+                return
+            }
+
+            let messageSub = self.subscribeToRoomMessages(
+                room: roomToSubscribeTo,
+                delegate: roomDelegate,
+                messageLimit: messageLimit
+            )
+            let cursorSub = self.subscribeToRoomCursors(
+                room: roomToSubscribeTo,
+                delegate: roomDelegate
+            )
+
+            room.subscription = PCRoomSubscription(
+                messageSubscription: messageSub,
+                cursorSubscription: cursorSub
+            )
+        }
+    }
+
+    fileprivate func subscribeToRoomMessages(
+        room: PCRoom,
+        delegate: PCRoomDelegate,
+        messageLimit: Int
+    ) -> PCMessageSubscription {
         let path = "/rooms/\(room.id)"
 
         // TODO: What happens if you provide both a message_limit and a Last-Event-ID?
@@ -838,28 +833,29 @@ public final class PCCurrentUser {
             requestOptions: subscribeRequest
         )
 
-        room.subscription = PCRoomSubscription(
-            delegate: roomDelegate,
+        let messageSubscription = PCMessageSubscription(
+            delegate: delegate,
             resumableSubscription: resumableSub,
             logger: self.instance.logger,
-            basicMessageEnricher: PCBasicMessageEnricher(userStore: self.userStore, room: room, logger: self.instance.logger)
+            basicMessageEnricher: PCBasicMessageEnricher(
+                userStore: self.userStore,
+                // TODO: This should probably be a room store
+                room: room,
+                logger: self.instance.logger
+            )
         )
 
         self.instance.subscribeWithResume(
             with: &resumableSub,
             using: subscribeRequest,
-            onEvent: room.subscription?.handleEvent
-
-            // TODO: This will probably be replaced by the state change delegate function, with an associated type, maybe
-            //            onError: { error in
-            //                roomDelegate.receivedError(error)
-            //            }
+            onEvent: messageSubscription.handleEvent
+            // TODO: Should we be handling onError here somehow?
         )
 
-        self.subscribeToCursors(room: room, delegate: roomDelegate)
+        return messageSubscription
     }
 
-    fileprivate func subscribeToCursors(room: PCRoom, delegate: PCRoomDelegate) {
+    fileprivate func subscribeToRoomCursors(room: PCRoom, delegate: PCRoomDelegate) -> PCCursorSubscription {
         let path = "/cursors/\(PCCursorType.read.rawValue)/rooms/\(room.id)"
 
         let subscribeRequest = PPRequestOptions(
@@ -872,25 +868,26 @@ public final class PCCurrentUser {
             requestOptions: subscribeRequest
         )
 
-        let basicCursorEnricher = PCBasicCursorEnricher(
-            userStore: self.userStore,
-            room: room,
-            logger: self.cursorsInstance.logger
-        )
-
-        room.cursorSubscription = PCCursorSubscription(
+        let cursorSubscription = PCCursorSubscription(
             delegate: delegate,
             resumableSubscription: resumableSub,
-            basicCursorEnricher: basicCursorEnricher,
-            handleNewCursor: { room.newCursorHandler($0, self.id) },
-            logger: self.cursorsInstance.logger
+            cursorStore: cursorStore,
+            connectionCoordinator: connectionCoordinator,
+            logger: self.cursorsInstance.logger,
+            initialStateHandler: { err in
+                // TODO: Only consider the room subscription open when both the
+                // room subscription and cursor subscription have opened
+            }
         )
 
         self.cursorsInstance.subscribeWithResume(
             with: &resumableSub,
             using: subscribeRequest,
-            onEvent: room.cursorSubscription?.handleEvent
+            onEvent: cursorSubscription.handleEvent
+            // TODO: Should we be handling onError here somehow?
         )
+
+        return cursorSubscription
     }
 
     public func fetchMessagesFromRoom(
@@ -985,7 +982,21 @@ public final class PCCurrentUser {
         )
     }
 
-    public func setCursor(position: Int, roomId: Int, completionHandler: @escaping ErrorCompletionHandler) {
+    public func readCursor(roomId: Int, userId: String? = nil) throws -> PCCursor? {
+        guard let room = self.rooms.filter({ $0.id == roomId }).first else {
+            throw PCCurrentUserError.mustBeMemberOfRoom
+        }
+
+        let userIdToCheck = userId ?? self.id
+
+        if userIdToCheck != self.id && room.subscription == nil {
+            throw PCCurrentUserError.noSubscriptionToRoom(room)
+        }
+
+        return self.cursorStore.getSync(userId: userIdToCheck, roomId: roomId)
+    }
+
+    public func setReadCursor(position: Int, roomId: Int, completionHandler: @escaping ErrorCompletionHandler) {
         let cursorObject = [ "position": position ]
 
         guard JSONSerialization.isValidJSONObject(cursorObject) else {
@@ -1015,12 +1026,27 @@ public final class PCCurrentUser {
   }
 }
 
+public enum PCCurrentUserError: Error {
+    case noSubscriptionToRoom(PCRoom)
+    case mustBeMemberOfRoom
+}
+
+extension PCCurrentUserError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .noSubscriptionToRoom(room):
+            return "You must be subscribed to room \(room.name) to get read cursors from it"
+        case .mustBeMemberOfRoom:
+            return "You must be a member of a room to get the read cursors for it"
+        }
+    }
+}
+
 public enum PCMessageError: Error {
     case messageIdKeyMissingInMessageCreationResponse([String: Int])
 }
 
 extension PCMessageError: LocalizedError {
-
     public var errorDescription: String? {
         switch self {
         case let .messageIdKeyMissingInMessageCreationResponse(payload):

--- a/Sources/PCCursorStore.swift
+++ b/Sources/PCCursorStore.swift
@@ -1,0 +1,111 @@
+import Foundation
+import PusherPlatform
+
+public final class PCCursorStore {
+    public let instance: Instance
+    let roomStore: PCRoomStore
+    let userStore: PCGlobalUserStore
+    let basicCursorEnricher: PCBasicCursorEnricher
+
+    public var cursors: [String: PCCursor] = [:]
+
+    public init(instance: Instance, roomStore: PCRoomStore, userStore: PCGlobalUserStore) {
+        self.instance = instance
+        self.roomStore = roomStore
+        self.userStore = userStore
+        self.basicCursorEnricher = PCBasicCursorEnricher(
+            userStore: userStore,
+            roomStore: roomStore,
+            logger: instance.logger
+        )
+    }
+
+    public func get(userId: String, roomId: Int, completionHandler: @escaping (PCCursor?, Error?) -> Void) {
+        self.findOrGetCursor(userId: userId, roomId: roomId, completionHandler: completionHandler)
+    }
+
+    public func getSync(userId: String, roomId: Int) -> PCCursor? {
+        return self.cursors.first(where: { $0.key == key(userId, roomId) })?.value
+    }
+
+    public func set(_ basicCursor: PCBasicCursor, completionHandler: ((PCCursor?, Error?) -> Void)? = nil) {
+        self.basicCursorEnricher.enrich(basicCursor) { cursor, err in
+            guard let cursor = cursor, err == nil else {
+                self.instance.logger.log(
+                    "Error when enriching basic cursor: \(err!.localizedDescription)",
+                    logLevel: .error
+                )
+                completionHandler?(nil, err!)
+                return
+            }
+            self.set(userId: basicCursor.userId, roomId: basicCursor.roomId, cursor: cursor)
+            completionHandler?(cursor, nil)
+        }
+    }
+
+    fileprivate func set(userId: String, roomId: Int, cursor: PCCursor) {
+        self.cursors[key(userId, roomId)] = cursor
+    }
+
+    func findOrGetCursor(userId: String, roomId: Int, completionHandler: @escaping (PCCursor?, Error?) -> Void) {
+        if let cursorObj = self.cursors.first(where: { $0.key == key(userId, roomId) }) {
+            completionHandler(cursorObj.value, nil)
+        } else {
+            self.getCursor(userId: userId, roomId: roomId) { cursor, err in
+                guard err == nil else {
+                    self.instance.logger.log(err!.localizedDescription, logLevel: .error)
+                    completionHandler(nil, err!)
+                    return
+                }
+
+                completionHandler(cursor!, nil)
+            }
+        }
+    }
+
+    func getCursor(userId: String, roomId: Int, completionHandler: @escaping (PCCursor?, Error?) -> Void) {
+        let path = "/cursors/\(PCCursorType.read.rawValue)/rooms/\(roomId)/users/\(userId)"
+        let generalRequest = PPRequestOptions(method: HTTPMethod.GET.rawValue, path: path)
+
+        self.instance.requestWithRetry(
+            using: generalRequest,
+            onSuccess: { data in
+                guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) else {
+                    completionHandler(nil, PCError.failedToDeserializeJSON(data))
+                    return
+                }
+
+                guard let cursorPayload = jsonObject as? [String: Any] else {
+                    completionHandler(nil, PCError.failedToCastJSONObjectToDictionary(jsonObject))
+                    return
+                }
+
+                do {
+                    let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(cursorPayload)
+                    self.basicCursorEnricher.enrich(basicCursor) { cursor, err in
+                        guard let cursor = cursor, err == nil else {
+                            self.instance.logger.log(
+                                "Error when enriching basic cursor: \(err!.localizedDescription)",
+                                logLevel: .error
+                            )
+                            completionHandler(nil, err!)
+                            return
+                        }
+                        completionHandler(cursor, nil)
+                    }
+                } catch let err {
+                    self.instance.logger.log(err.localizedDescription, logLevel: .error)
+                    completionHandler(nil, err)
+                    return
+                }
+            },
+            onError: { error in
+                completionHandler(nil, error)
+            }
+        )
+    }
+
+    fileprivate func key(_ userId: String, _ roomId: Int) -> String {
+        return "\(userId)/\(roomId)"
+    }
+}

--- a/Sources/PCCursorSubscription.swift
+++ b/Sources/PCCursorSubscription.swift
@@ -2,24 +2,28 @@ import Foundation
 import PusherPlatform
 
 public final class PCCursorSubscription {
-    public var delegate: PCRoomDelegate?
+    // TODO: Do we still need this?
+    let delegate: PCRoomDelegate?
     let resumableSubscription: PPResumableSubscription
-    let basicCursorEnricher: PCBasicCursorEnricher
-    let handleNewCursor: (PCBasicCursor) -> Void
+    let cursorStore: PCCursorStore
+    let connectionCoordinator: PCConnectionCoordinator
     public var logger: PPLogger
+    let initialStateHandler: (Error?) -> Void
 
     init(
         delegate: PCRoomDelegate? = nil,
         resumableSubscription: PPResumableSubscription,
-        basicCursorEnricher: PCBasicCursorEnricher,
-        handleNewCursor: @escaping (PCBasicCursor) -> Void,
-        logger: PPLogger
+        cursorStore: PCCursorStore,
+        connectionCoordinator: PCConnectionCoordinator,
+        logger: PPLogger,
+        initialStateHandler: @escaping (Error?) -> Void
     ) {
         self.delegate = delegate
         self.resumableSubscription = resumableSubscription
-        self.basicCursorEnricher = basicCursorEnricher
-        self.handleNewCursor = handleNewCursor
+        self.cursorStore = cursorStore
+        self.connectionCoordinator = connectionCoordinator
         self.logger = logger
+        self.initialStateHandler = initialStateHandler
     }
 
     func handleEvent(eventId _: String, headers _: [String: String], data: Any) {
@@ -28,44 +32,108 @@ public final class PCCursorSubscription {
             return
         }
 
-        guard let eventTypeName = json["event_name"] as? String else {
-            self.logger.log("Event type name missing from room subscription event: \(json)", logLevel: .debug)
+        guard let eventNameString = json["event_name"] as? String else {
+            self.logger.log("Event type name missing from cursor subscription event: \(json)", logLevel: .debug)
             return
         }
 
-        let expectedEventTypeName = "new_cursor"
-
-        guard eventTypeName == expectedEventTypeName else {
-            self.logger.log("Expected event type name to be \(expectedEventTypeName) but got \(eventTypeName)", logLevel: .debug)
+        guard let eventName = PCCursorEventName(rawValue: eventNameString) else {
+            self.logger.log("Unsupported API event name received: \(eventNameString)", logLevel: .debug)
             return
         }
 
-        guard let basicCursorPayload = json["data"] as? [String: Any] else {
-            self.logger.log("Missing data for cursor subscription event: \(json)", logLevel: .debug)
+        guard let apiEventData = json["data"] as? [String: Any] else {
+            self.logger.log("Data missing for API event: \(json)", logLevel: .debug)
             return
         }
 
+        switch eventName {
+        case .initial_state:
+            parseInitialStatePayload(eventName, data: apiEventData)
+        case .new_cursor:
+            parseNewCursorPayload(eventName, data: apiEventData)
+        }
+    }
+
+    func end() {
+        self.resumableSubscription.end()
+    }
+}
+
+extension PCCursorSubscription {
+    
+    fileprivate func parseInitialStatePayload(_ eventName: PCCursorEventName, data: [String: Any]) {
+        guard let cursorsPayload = data["cursors"] as? [[String: Any]] else {
+            let error = PCCursorsEventError.keyNotPresentInEventPayload(
+                key: "cursors",
+                apiEventName: eventName,
+                payload: data
+            )
+            initialStateHandler(error)
+            return
+        }
+
+        guard cursorsPayload.count > 0 else {
+            initialStateHandler(nil)
+            return
+        }
+
+        let cursorsProgressCounter = PCProgressCounter(totalCount: cursorsPayload.count, labelSuffix: "initial-state-cursors")
+
+        cursorsPayload.forEach { cursorPayload in
+            do {
+                let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(cursorPayload)
+                self.cursorStore.set(basicCursor)
+                if cursorsProgressCounter.incrementSuccessAndCheckIfFinished() {
+                    self.initialStateHandler(nil)
+                }
+            } catch let err {
+                self.logger.log(err.localizedDescription, logLevel: .debug)
+                if cursorsProgressCounter.incrementFailedAndCheckIfFinished() {
+                    self.initialStateHandler(err)
+                }
+            }
+        }
+    }
+
+    fileprivate func parseNewCursorPayload(_ eventName: PCCursorEventName, data: [String: Any]) {
         do {
-            let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(basicCursorPayload)
-            self.handleNewCursor(basicCursor)
-
-            self.basicCursorEnricher.enrich(basicCursor) { [weak self] cursor, err in
-                guard let strongSelf = self else {
-                    print("self is nil when enrichment of basicCursor has completed")
-                    return
-                }
-
+            let basicCursor = try PCPayloadDeserializer.createBasicCursorFromPayload(data)
+            self.cursorStore.set(basicCursor) { cursor, err in
                 guard let cursor = cursor, err == nil else {
-                    strongSelf.logger.log(err!.localizedDescription, logLevel: .debug)
+                    self.logger.log(
+                        "Error when adding basic cursor to cursor store: \(err!.localizedDescription)",
+                        logLevel: .error
+                    )
                     return
                 }
 
-                strongSelf.delegate?.newCursor(cursor: cursor)
-                strongSelf.logger.log("New cursor: \(cursor.debugDescription)", logLevel: .verbose)
+                self.logger.log("New cursor: \(cursor.debugDescription)", logLevel: .verbose)
+                self.delegate?.newCursor(cursor: cursor)
             }
         } catch let err {
             self.logger.log(err.localizedDescription, logLevel: .debug)
             // TODO: Should we call the delegate error func?
+        }
+    }
+
+}
+
+public enum PCCursorEventName: String {
+    case initial_state
+    case new_cursor
+}
+
+// TODO: This is the same across all subscription classes I think
+public enum PCCursorsEventError: Error {
+    case keyNotPresentInEventPayload(key: String, apiEventName: PCCursorEventName, payload: [String: Any])
+}
+
+extension PCCursorsEventError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .keyNotPresentInEventPayload(key, apiEventName, payload):
+            return "\(key) missing in \(apiEventName.rawValue) API event payload: \(payload)"
         }
     }
 }

--- a/Sources/PCMessageSubscription.swift
+++ b/Sources/PCMessageSubscription.swift
@@ -1,0 +1,73 @@
+import Foundation
+import PusherPlatform
+
+public final class PCMessageSubscription {
+    public var delegate: PCRoomDelegate?
+    let resumableSubscription: PPResumableSubscription
+    public var logger: PPLogger
+    let basicMessageEnricher: PCBasicMessageEnricher
+
+    init(
+        delegate: PCRoomDelegate? = nil,
+        resumableSubscription: PPResumableSubscription,
+        logger: PPLogger,
+        basicMessageEnricher: PCBasicMessageEnricher
+    ) {
+        self.delegate = delegate
+        self.resumableSubscription = resumableSubscription
+        self.logger = logger
+        self.basicMessageEnricher = basicMessageEnricher
+    }
+
+    func handleEvent(eventId _: String, headers _: [String: String], data: Any) {
+        guard let json = data as? [String: Any] else {
+            self.logger.log("Failed to cast JSON object to Dictionary: \(data)", logLevel: .debug)
+            return
+        }
+
+        guard let eventTypeName = json["event_name"] as? String else {
+            self.logger.log("Event type name missing from room subscription event: \(json)", logLevel: .debug)
+            return
+        }
+
+        let expectedEventTypeName = "new_message"
+
+        guard eventTypeName == expectedEventTypeName else {
+            self.logger.log("Expected event type name to be \(expectedEventTypeName) but got \(eventTypeName)", logLevel: .debug)
+            return
+        }
+
+        guard let messagePayload = json["data"] as? [String: Any] else {
+            self.logger.log("Missing data for room subscription event: \(json)", logLevel: .debug)
+            return
+        }
+
+        do {
+            let basicMessage = try PCPayloadDeserializer.createBasicMessageFromPayload(messagePayload)
+
+            self.basicMessageEnricher.enrich(basicMessage) { [weak self] message, err in
+                guard let strongSelf = self else {
+                    print("self is nil when enrichment of basicMessage has completed")
+                    return
+                }
+
+                guard let message = message, err == nil else {
+                    strongSelf.logger.log(err!.localizedDescription, logLevel: .debug)
+                    return
+                }
+
+                strongSelf.delegate?.newMessage(message: message)
+                strongSelf.logger.log("Room received new message: \(message.debugDescription)", logLevel: .verbose)
+            }
+        } catch let err {
+            self.logger.log(err.localizedDescription, logLevel: .debug)
+
+            // TODO: Should we call the delegate error func?
+        }
+    }
+
+    func end() {
+        self.resumableSubscription.end()
+    }
+}
+

--- a/Sources/PCPayloadDeserializer.swift
+++ b/Sources/PCPayloadDeserializer.swift
@@ -24,6 +24,8 @@ struct PCPayloadDeserializer {
         cursorsInstance: Instance,
         presenceInstance: Instance,
         userStore: PCGlobalUserStore,
+        roomStore: PCRoomStore,
+        cursorStore: PCCursorStore,
         connectionCoordinator: PCConnectionCoordinator
     ) throws -> PCCurrentUser {
         let basicUser = try createBasicUserFromPayload(userPayload)
@@ -41,6 +43,8 @@ struct PCPayloadDeserializer {
             cursorsInstance: cursorsInstance,
             presenceInstance: presenceInstance,
             userStore: userStore,
+            roomStore: roomStore,
+            cursorStore: cursorStore,
             connectionCoordinator: connectionCoordinator
         )
     }

--- a/Sources/PCPresenceSubscription.swift
+++ b/Sources/PCPresenceSubscription.swift
@@ -146,7 +146,10 @@ extension PCPresenceSubscription {
                     strongSelf.presenceInstance.logger.log("\(user.displayName) came offline", logLevel: .verbose)
                 case .unknown:
                     // This should never be the case
-                    strongSelf.presenceInstance.logger.log("Somehow the presence state of user \(user.debugDescription) is unknown", logLevel: .debug)
+                    strongSelf.presenceInstance.logger.log(
+                        "Somehow the presence state of user \(user.debugDescription) is unknown",
+                        logLevel: .debug
+                    )
                     return
                 }
 
@@ -203,7 +206,10 @@ extension PCPresenceSubscription {
         userStore.handleInitialPresencePayloadsAfterRoomJoin(userStates) {
             self.roomStore.rooms.forEach { room in
                 room.subscription?.delegate?.usersUpdated()
-                self.presenceInstance.logger.log("Users updated " + room.users.map { "\($0.id), \($0.name ?? ""), \($0.presenceState.rawValue)" }.joined(separator: "; "), logLevel: .verbose)
+                self.presenceInstance.logger.log(
+                    "Users updated " + room.users.map { "\($0.id), \($0.name ?? ""), \($0.presenceState.rawValue)" }.joined(separator: "; "),
+                    logLevel: .verbose
+                )
             }
         }
     }

--- a/Sources/PCPresenceSubscription.swift
+++ b/Sources/PCPresenceSubscription.swift
@@ -110,7 +110,7 @@ extension PCPresenceSubscription {
             }
 
             strongSelf.roomStore.rooms.forEach { room in
-                room.subscription?.delegate?.usersUpdated()
+                room.subscription?.delegate.usersUpdated()
                 strongSelf.presenceInstance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
             }
             strongSelf.connectionCoordinator.connectionEventCompleted(PCConnectionEvent(presenceSubscription: strongSelf, error: nil))
@@ -161,8 +161,8 @@ extension PCPresenceSubscription {
                     }
 
                     switch presencePayload.state {
-                    case .online: room.subscription?.delegate?.userCameOnlineInRoom(user: user)
-                    case .offline: room.subscription?.delegate?.userWentOfflineInRoom(user: user)
+                    case .online: room.subscription?.delegate.userCameOnlineInRoom(user: user)
+                    case .offline: room.subscription?.delegate.userWentOfflineInRoom(user: user)
                     default: return
                     }
                 }
@@ -205,7 +205,7 @@ extension PCPresenceSubscription {
         // TODO: So much duplication
         userStore.handleInitialPresencePayloadsAfterRoomJoin(userStates) {
             self.roomStore.rooms.forEach { room in
-                room.subscription?.delegate?.usersUpdated()
+                room.subscription?.delegate.usersUpdated()
                 self.presenceInstance.logger.log(
                     "Users updated " + room.users.map { "\($0.id), \($0.name ?? ""), \($0.presenceState.rawValue)" }.joined(separator: "; "),
                     logLevel: .verbose

--- a/Sources/PCRoom.swift
+++ b/Sources/PCRoom.swift
@@ -11,18 +11,6 @@ public final class PCRoom {
     public internal(set) var deletedAt: String?
 
     public internal(set) var subscription: PCRoomSubscription?
-    public internal(set) var cursorSubscription: PCCursorSubscription?
-
-    public internal(set) var currentUserCursor: PCBasicCursorState?
-
-    lazy var newCursorHandler = { (cursor: PCBasicCursor, currentUserId: String) in
-        self.cursors[cursor.userId] = cursor
-        if cursor.userId == currentUserId {
-            self.currentUserCursor = .set(cursor)
-        }
-    }
-
-    public internal(set) var cursors: [String: PCBasicCursor] = [:]
 
     public internal(set) var userIds: Set<String>
 
@@ -95,21 +83,5 @@ extension PCRoom: Hashable {
 extension PCRoom: CustomDebugStringConvertible {
     public var debugDescription: String {
         return "ID: \(self.id) Name: \(self.name) Private: \(self.isPrivate)"
-    }
-}
-
-public enum PCBasicCursorState {
-    case unset
-    case set(PCBasicCursor)
-}
-
-extension PCBasicCursorState: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        switch self {
-        case .unset:
-            return "No cursor has been set yet for the current user"
-        case .set(let basicCursor):
-            return "Cursor set with message ID: \(basicCursor.position), updated at: \(basicCursor.updatedAt)"
-        }
     }
 }

--- a/Sources/PCRoomSubscription.swift
+++ b/Sources/PCRoomSubscription.swift
@@ -2,67 +2,26 @@ import Foundation
 import PusherPlatform
 
 public final class PCRoomSubscription {
-    public var delegate: PCRoomDelegate?
-    let resumableSubscription: PPResumableSubscription
-    public var logger: PPLogger
-    let basicMessageEnricher: PCBasicMessageEnricher
+    let messageSubscription: PCMessageSubscription
+    let cursorSubscription: PCCursorSubscription
 
-    init(
-        delegate: PCRoomDelegate? = nil,
-        resumableSubscription: PPResumableSubscription,
-        logger: PPLogger,
-        basicMessageEnricher: PCBasicMessageEnricher
-    ) {
-        self.delegate = delegate
-        self.resumableSubscription = resumableSubscription
-        self.logger = logger
-        self.basicMessageEnricher = basicMessageEnricher
+    // TODO: Maybe the RoomSubscription should just store the delegate?
+    public var delegate: PCRoomDelegate? {
+        get {
+            return messageSubscription.delegate
+        }
     }
 
-    func handleEvent(eventId _: String, headers _: [String: String], data: Any) {
-        guard let json = data as? [String: Any] else {
-            self.logger.log("Failed to cast JSON object to Dictionary: \(data)", logLevel: .debug)
-            return
-        }
+    init(
+        messageSubscription: PCMessageSubscription,
+        cursorSubscription: PCCursorSubscription
+    ) {
+        self.messageSubscription = messageSubscription
+        self.cursorSubscription = cursorSubscription
+    }
 
-        guard let eventTypeName = json["event_name"] as? String else {
-            self.logger.log("Event type name missing from room subscription event: \(json)", logLevel: .debug)
-            return
-        }
-
-        let expectedEventTypeName = "new_message"
-
-        guard eventTypeName == expectedEventTypeName else {
-            self.logger.log("Expected event type name to be \(expectedEventTypeName) but got \(eventTypeName)", logLevel: .debug)
-            return
-        }
-
-        guard let messagePayload = json["data"] as? [String: Any] else {
-            self.logger.log("Missing data for room subscription event: \(json)", logLevel: .debug)
-            return
-        }
-
-        do {
-            let basicMessage = try PCPayloadDeserializer.createBasicMessageFromPayload(messagePayload)
-
-            self.basicMessageEnricher.enrich(basicMessage) { [weak self] message, err in
-                guard let strongSelf = self else {
-                    print("self is nil when enrichment of basicMessage has completed")
-                    return
-                }
-
-                guard let message = message, err == nil else {
-                    strongSelf.logger.log(err!.localizedDescription, logLevel: .debug)
-                    return
-                }
-
-                strongSelf.delegate?.newMessage(message: message)
-                strongSelf.logger.log("Room received new message: \(message.debugDescription)", logLevel: .verbose)
-            }
-        } catch let err {
-            self.logger.log(err.localizedDescription, logLevel: .debug)
-
-            // TODO: Should we call the delegate error func?
-        }
+    func end() {
+        self.messageSubscription.end()
+        self.cursorSubscription.end()
     }
 }

--- a/Sources/PCRoomSubscription.swift
+++ b/Sources/PCRoomSubscription.swift
@@ -4,20 +4,16 @@ import PusherPlatform
 public final class PCRoomSubscription {
     let messageSubscription: PCMessageSubscription
     let cursorSubscription: PCCursorSubscription
-
-    // TODO: Maybe the RoomSubscription should just store the delegate?
-    public var delegate: PCRoomDelegate? {
-        get {
-            return messageSubscription.delegate
-        }
-    }
+    public var delegate: PCRoomDelegate
 
     init(
         messageSubscription: PCMessageSubscription,
-        cursorSubscription: PCCursorSubscription
+        cursorSubscription: PCCursorSubscription,
+        delegate: PCRoomDelegate
     ) {
         self.messageSubscription = messageSubscription
         self.cursorSubscription = cursorSubscription
+        self.delegate = delegate
     }
 
     func end() {

--- a/Sources/PCSharedInstanceOptions.swift
+++ b/Sources/PCSharedInstanceOptions.swift
@@ -1,0 +1,10 @@
+import Foundation
+import PusherPlatform
+
+struct PCSharedInstanceOptions {
+    let locator: String
+    let sdkInfo: PPSDKInfo
+    let tokenProvider: PPTokenProvider
+    let baseClient: PPBaseClient
+    let logger: PPLogger
+}

--- a/Sources/PCUserSubscription.swift
+++ b/Sources/PCUserSubscription.swift
@@ -185,7 +185,7 @@ extension PCUserSubscription {
                         )
 
                         if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                            room.subscription?.delegate?.usersUpdated()
+                            room.subscription?.delegate.usersUpdated()
                             strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                         }
 
@@ -195,7 +195,7 @@ extension PCUserSubscription {
                     room.userStore.addOrMerge(user)
 
                     if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                        room.subscription?.delegate?.usersUpdated()
+                        room.subscription?.delegate.usersUpdated()
                         strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                     }
                 }
@@ -349,7 +349,7 @@ extension PCUserSubscription {
                 room.userIds.insert(addedOrMergedUser.id)
 
                 strongSelf.delegate.userJoinedRoom(room: room, user: addedOrMergedUser)
-                room.subscription?.delegate?.userJoined(user: addedOrMergedUser)
+                room.subscription?.delegate.userJoined(user: addedOrMergedUser)
                 strongSelf.instance.logger.log("User \(user.displayName) joined room: \(room.name)", logLevel: .verbose)
             }
         }
@@ -419,7 +419,7 @@ extension PCUserSubscription {
                 room.userStore.remove(id: user.id)
 
                 strongSelf.delegate.userLeftRoom(room: room, user: user)
-                room.subscription?.delegate?.userLeft(user: user)
+                room.subscription?.delegate.userLeft(user: user)
                 strongSelf.instance.logger.log("User \(user.displayName) left room: \(room.name)", logLevel: .verbose)
             }
         }
@@ -464,7 +464,7 @@ extension PCUserSubscription {
                 }
 
                 strongSelf.delegate.userStartedTyping(room: room, user: user)
-                room.subscription?.delegate?.userStartedTyping(user: user)
+                room.subscription?.delegate.userStartedTyping(user: user)
                 strongSelf.instance.logger.log("\(user.displayName) started typing in room \(room.name)", logLevel: .verbose)
             }
         }
@@ -509,7 +509,7 @@ extension PCUserSubscription {
                 }
 
                 strongSelf.delegate.userStoppedTyping(room: room, user: user)
-                room.subscription?.delegate?.userStoppedTyping(user: user)
+                room.subscription?.delegate.userStoppedTyping(user: user)
                 strongSelf.instance.logger.log("\(user.displayName) stopped typing in room \(room.name)", logLevel: .verbose)
             }
         }

--- a/Sources/PCUserSubscription.swift
+++ b/Sources/PCUserSubscription.swift
@@ -15,6 +15,7 @@ public final class PCUserSubscription {
     let userId: String
     let pathFriendlyUserId: String
     let connectionCoordinator: PCConnectionCoordinator
+    let initialStateHandler: ((roomsPayload: [[String: Any]], currentUserPayload: [String: Any])) -> Void
 
     public var currentUser: PCCurrentUser?
 
@@ -28,7 +29,8 @@ public final class PCUserSubscription {
         delegate: PCChatManagerDelegate,
         userId: String,
         pathFriendlyUserId: String,
-        connectionCoordinator: PCConnectionCoordinator
+        connectionCoordinator: PCConnectionCoordinator,
+        initialStateHandler: @escaping ((roomsPayload: [[String: Any]], currentUserPayload: [String: Any])) -> Void
     ) {
         self.instance = instance
         self.filesInstance = filesInstance
@@ -40,6 +42,7 @@ public final class PCUserSubscription {
         self.userId = userId
         self.pathFriendlyUserId = pathFriendlyUserId
         self.connectionCoordinator = connectionCoordinator
+        self.initialStateHandler = initialStateHandler
     }
 
     public func handleEvent(eventId _: String, headers _: [String: String], data: Any) {
@@ -101,6 +104,10 @@ public final class PCUserSubscription {
         }
     }
 
+    func end() {
+        self.resumableSubscription.end()
+    }
+
     fileprivate func informConnectionCoordinatorOfCurrentUserCompletion(currentUser: PCCurrentUser?, error: Error?) {
         connectionCoordinator.connectionEventCompleted(PCConnectionEvent(currentUser: currentUser, error: error))
     }
@@ -124,11 +131,11 @@ extension PCUserSubscription {
             return
         }
 
-        guard let userPayload = data["current_user"] as? [String: Any] else {
+        guard let currentUserPayload = data["current_user"] as? [String: Any] else {
             informConnectionCoordinatorOfCurrentUserCompletion(
                 currentUser: nil,
                 error: PCAPIEventError.keyNotPresentInEventPayload(
-                    key: "user",
+                    key: "current_user",
                     apiEventName: eventName,
                     payload: data
                 )
@@ -136,165 +143,7 @@ extension PCUserSubscription {
             return
         }
 
-        let receivedCurrentUser: PCCurrentUser
-
-        do {
-            receivedCurrentUser = try PCPayloadDeserializer.createCurrentUserFromPayload(
-                userPayload,
-                id: self.userId,
-                pathFriendlyId: self.pathFriendlyUserId,
-                instance: self.instance,
-                filesInstance: self.filesInstance,
-                cursorsInstance: self.cursorsInstance,
-                presenceInstance: self.presenceInstance,
-                userStore: userStore,
-                connectionCoordinator: connectionCoordinator
-            )
-        } catch let err {
-            informConnectionCoordinatorOfCurrentUserCompletion(
-                currentUser: nil,
-                error: err
-            )
-            return
-        }
-
-        let wasExistingCurrentUser = self.currentUser != nil
-
-        // If the currentUser property is already set then the assumption is that there was
-        // already a user subscription and so instead of setting the property to a new
-        // PCCurrentUser, we update the existing one to have the most up-to-date state
-        if let currentUser = self.currentUser {
-            currentUser.updateWithPropertiesOf(receivedCurrentUser)
-        } else {
-            self.currentUser = receivedCurrentUser
-        }
-
-        guard roomsPayload.count > 0 else {
-            self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
-            // There are no users to fetch information about so we are safe to inform
-            // the connection coordinator of a success immediately
-            self.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: [], error: nil)
-            self.currentUser!.setupPresenceSubscription(delegate: self.delegate)
-            return
-        }
-
-        let roomsAddedToRoomStoreProgressCounter = PCProgressCounter(
-            totalCount: roomsPayload.count,
-            labelSuffix: "roomstore-room-append"
-        )
-
-        var combinedRoomUserIds = Set<String>()
-        var roomsFromConnection = [PCRoom]()
-
-        roomsPayload.forEach { roomPayload in
-            do {
-                let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
-
-                combinedRoomUserIds.formUnion(room.userIds)
-                roomsFromConnection.append(room)
-
-                self.currentUser!.roomStore.addOrMerge(room) { _ in
-                    if roomsAddedToRoomStoreProgressCounter.incrementSuccessAndCheckIfFinished() {
-                        self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
-                        self.fetchInitialUserInformationForUserIds(combinedRoomUserIds, currentUser: self.currentUser!)
-                        if wasExistingCurrentUser {
-                            self.reconcileExistingRoomStoreWithRoomsReceivedOnConnection(roomsFromConnection: roomsFromConnection)
-                        }
-                    }
-                }
-            } catch let err {
-                self.instance.logger.log(
-                    "Incomplete room payload in initial_state event: \(roomPayload). Error: \(err.localizedDescription)",
-                    logLevel: .debug
-                )
-                if roomsAddedToRoomStoreProgressCounter.incrementFailedAndCheckIfFinished() {
-                    self.informConnectionCoordinatorOfCurrentUserCompletion(currentUser: self.currentUser, error: nil)
-                    self.fetchInitialUserInformationForUserIds(combinedRoomUserIds, currentUser: self.currentUser!)
-                    if wasExistingCurrentUser {
-                        self.reconcileExistingRoomStoreWithRoomsReceivedOnConnection(roomsFromConnection: roomsFromConnection)
-                    }
-                }
-            }
-        }
-    }
-
-    fileprivate func fetchInitialUserInformationForUserIds(_ userIds: Set<String>, currentUser: PCCurrentUser) {
-        self.userStore.initialFetchOfUsersWithIds(userIds) { users, err in
-            guard err == nil else {
-                self.instance.logger.log(
-                    "Unable to fetch user information after successful connection: \(err!.localizedDescription)",
-                    logLevel: .debug
-                )
-                self.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: nil, error: err!)
-                return
-            }
-
-            let combinedRoomUsersProgressCounter = PCProgressCounter(totalCount: currentUser.roomStore.rooms.count, labelSuffix: "room-users-combined")
-
-            // TODO: This could be a lot more efficient
-            currentUser.roomStore.rooms.forEach { room in
-                let roomUsersProgressCounter = PCProgressCounter(totalCount: room.userIds.count, labelSuffix: "room-users")
-
-                room.userIds.forEach { userId in
-                    self.userStore.user(id: userId) { [weak self] user, err in
-                        guard let strongSelf = self else {
-                            print("self is nil when user store returns user after initial fetch of users")
-                            return
-                        }
-
-                        guard let user = user, err == nil else {
-                            strongSelf.instance.logger.log(
-                                "Unable to add user with id \(userId) to room \(room.name): \(err!.localizedDescription)",
-                                logLevel: .debug
-                            )
-                            if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                                room.subscription?.delegate?.usersUpdated()
-                                strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
-
-                                if combinedRoomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                                    strongSelf.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: nil, error: err!)
-                                    currentUser.setupPresenceSubscription(delegate: strongSelf.delegate)
-                                }
-                            }
-                            return
-                        }
-
-                        room.userStore.addOrMerge(user)
-
-                        if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                            room.subscription?.delegate?.usersUpdated()
-                            strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
-
-                            if combinedRoomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                                strongSelf.informConnectionCoordinatorOfInitialUsersFetchCompletion(users: users, error: nil)
-                                currentUser.setupPresenceSubscription(delegate: strongSelf.delegate)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fileprivate func reconcileExistingRoomStoreWithRoomsReceivedOnConnection(roomsFromConnection: [PCRoom]) {
-        guard let currentUser = self.currentUser else {
-            self.instance.logger.log("currentUser property not set on PCUserSubscription", logLevel: .error)
-            self.delegate.error(error: PCError.currentUserIsNil)
-            return
-        }
-
-        let roomStoreRooms = Set<PCRoom>(currentUser.roomStore.rooms.underlyingArray)
-        let mostRecentConnectionRooms = Set<PCRoom>(roomsFromConnection)
-        let noLongerAMemberOfRooms = roomStoreRooms.subtracting(mostRecentConnectionRooms)
-
-        noLongerAMemberOfRooms.forEach { room in
-
-            // TODO: Not sure if this is the best way of communicating that while the subscription
-            // was closed there was an event that meant that the current user is no longer a
-            // member of a given room
-
-            self.delegate.removedFromRoom(room: room)
-        }
+        self.initialStateHandler((roomsPayload: roomsPayload, currentUserPayload: currentUserPayload))
     }
 
     fileprivate func parseAddedToRoomPayload(_ eventName: PCAPIEventName, data: [String: Any]) {
@@ -470,6 +319,7 @@ extension PCUserSubscription {
             return
         }
 
+        // TODO: Why not weak self here?
         currentUser.roomStore.room(id: roomId) { room, err in
             guard let room = room, err == nil else {
                 self.instance.logger.log(
@@ -534,6 +384,7 @@ extension PCUserSubscription {
             return
         }
 
+        // TODO: Why not weak self here?
         currentUser.roomStore.room(id: roomId) { room, err in
             guard let room = room, err == nil else {
                 self.instance.logger.log(
@@ -592,6 +443,7 @@ extension PCUserSubscription {
             return
         }
 
+        // TODO: Why not weak self here?
         currentUser.roomStore.room(id: roomId) { room, err in
             guard let room = room, err == nil else {
                 self.instance.logger.log(err!.localizedDescription, logLevel: .error)
@@ -636,6 +488,7 @@ extension PCUserSubscription {
             return
         }
 
+        // TODO: Why not weak self here?
         currentUser.roomStore.room(id: roomId) { room, err in
             guard let room = room, err == nil else {
                 self.instance.logger.log(err!.localizedDescription, logLevel: .error)

--- a/Sources/PPTypealiases.swift
+++ b/Sources/PPTypealiases.swift
@@ -10,6 +10,7 @@ public typealias PCDownloadFileDestination = PPDownloadFileDestination
 public typealias PCDownloadOptions = PPDownloadOptions
 public typealias PCRetryStrategy = PPRetryStrategy
 public typealias PCDefaultRetryStrategy = PPDefaultRetryStrategy
+public typealias PCBaseClient = PPBaseClient
 
 
 public func PCSuggestedDownloadDestination(


### PR DESCRIPTION
### What?

* `subscribeToRoom` attempts to join the room if necessary.
* Establish user cursor subscription on connection.
* `PCRoomSubscription` -> `PCMessageSubscription`.
* `PCRoomSubscription` now holds reference to a `PCMessageSubscription` and a `PCCursorSubscription`.

### Why?

More closely match the JS SDK

----

CC @hamchapman