### PR TITLE
Fix memory leak with the PCRoomDelegate

### DIFF
--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -271,7 +271,7 @@ import PusherPlatform
                                 logLevel: .debug
                             )
                             if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                                room.subscription?.delegate.usersUpdated()
+                                room.subscription?.delegate?.usersUpdated()
                                 strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
 
                                 if combinedRoomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
@@ -284,7 +284,7 @@ import PusherPlatform
                         room.userStore.addOrMerge(user)
 
                         if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                            room.subscription?.delegate.usersUpdated()
+                            room.subscription?.delegate?.usersUpdated()
                             strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
 
                             if combinedRoomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -382,7 +382,7 @@ public final class PCCurrentUser {
                     )
 
                     if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                        room.subscription?.delegate.usersUpdated()
+                        room.subscription?.delegate?.usersUpdated()
                         strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                     }
 
@@ -392,7 +392,7 @@ public final class PCCurrentUser {
                 room.userStore.addOrMerge(user)
 
                 if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                    room.subscription?.delegate.usersUpdated()
+                    room.subscription?.delegate?.usersUpdated()
                     strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                 }
             }

--- a/Sources/PCCursorSubscription.swift
+++ b/Sources/PCCursorSubscription.swift
@@ -3,7 +3,7 @@ import PusherPlatform
 
 public final class PCCursorSubscription {
     // TODO: Do we still need this?
-    let delegate: PCRoomDelegate?
+    weak var delegate: PCRoomDelegate?
     let resumableSubscription: PPResumableSubscription
     let cursorStore: PCCursorStore
     let connectionCoordinator: PCConnectionCoordinator

--- a/Sources/PCMessageSubscription.swift
+++ b/Sources/PCMessageSubscription.swift
@@ -2,7 +2,7 @@ import Foundation
 import PusherPlatform
 
 public final class PCMessageSubscription {
-    public var delegate: PCRoomDelegate?
+    public weak var delegate: PCRoomDelegate?
     let resumableSubscription: PPResumableSubscription
     public var logger: PPLogger
     let basicMessageEnricher: PCBasicMessageEnricher

--- a/Sources/PCPresenceSubscription.swift
+++ b/Sources/PCPresenceSubscription.swift
@@ -110,7 +110,7 @@ extension PCPresenceSubscription {
             }
 
             strongSelf.roomStore.rooms.forEach { room in
-                room.subscription?.delegate.usersUpdated()
+                room.subscription?.delegate?.usersUpdated()
                 strongSelf.presenceInstance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
             }
             strongSelf.connectionCoordinator.connectionEventCompleted(PCConnectionEvent(presenceSubscription: strongSelf, error: nil))
@@ -161,8 +161,8 @@ extension PCPresenceSubscription {
                     }
 
                     switch presencePayload.state {
-                    case .online: room.subscription?.delegate.userCameOnlineInRoom(user: user)
-                    case .offline: room.subscription?.delegate.userWentOfflineInRoom(user: user)
+                    case .online: room.subscription?.delegate?.userCameOnlineInRoom(user: user)
+                    case .offline: room.subscription?.delegate?.userWentOfflineInRoom(user: user)
                     default: return
                     }
                 }
@@ -205,7 +205,7 @@ extension PCPresenceSubscription {
         // TODO: So much duplication
         userStore.handleInitialPresencePayloadsAfterRoomJoin(userStates) {
             self.roomStore.rooms.forEach { room in
-                room.subscription?.delegate.usersUpdated()
+                room.subscription?.delegate?.usersUpdated()
                 self.presenceInstance.logger.log(
                     "Users updated " + room.users.map { "\($0.id), \($0.name ?? ""), \($0.presenceState.rawValue)" }.joined(separator: "; "),
                     logLevel: .verbose

--- a/Sources/PCRoomDelegate.swift
+++ b/Sources/PCRoomDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PusherPlatform
 
-public protocol PCRoomDelegate {
+public protocol PCRoomDelegate: NSObjectProtocol {
     func newMessage(message: PCMessage)
 
     func userStartedTyping(user: PCUser)

--- a/Sources/PCRoomSubscription.swift
+++ b/Sources/PCRoomSubscription.swift
@@ -2,7 +2,7 @@ import Foundation
 import PusherPlatform
 
 public final class PCRoomSubscription {
-    let messageSubscription: PCMessageSubscription
+    weak var messageSubscription: PCMessageSubscription?
     weak var cursorSubscription: PCCursorSubscription?
     public weak var delegate: PCRoomDelegate?
 
@@ -17,7 +17,10 @@ public final class PCRoomSubscription {
     }
 
     func end() {
-        self.messageSubscription.end()
-        self.cursorSubscription.end()
+        self.messageSubscription?.end()
+        self.cursorSubscription?.end()
+        
+        self.messageSubscription = nil
+        self.cursorSubscription = nil
     }
 }

--- a/Sources/PCRoomSubscription.swift
+++ b/Sources/PCRoomSubscription.swift
@@ -3,7 +3,7 @@ import PusherPlatform
 
 public final class PCRoomSubscription {
     let messageSubscription: PCMessageSubscription
-    let cursorSubscription: PCCursorSubscription
+    weak var cursorSubscription: PCCursorSubscription?
     public weak var delegate: PCRoomDelegate?
 
     init(

--- a/Sources/PCRoomSubscription.swift
+++ b/Sources/PCRoomSubscription.swift
@@ -4,7 +4,7 @@ import PusherPlatform
 public final class PCRoomSubscription {
     let messageSubscription: PCMessageSubscription
     let cursorSubscription: PCCursorSubscription
-    public var delegate: PCRoomDelegate
+    public weak var delegate: PCRoomDelegate?
 
     init(
         messageSubscription: PCMessageSubscription,

--- a/Sources/PCUserSubscription.swift
+++ b/Sources/PCUserSubscription.swift
@@ -185,7 +185,7 @@ extension PCUserSubscription {
                         )
 
                         if roomUsersProgressCounter.incrementFailedAndCheckIfFinished() {
-                            room.subscription?.delegate.usersUpdated()
+                            room.subscription?.delegate?.usersUpdated()
                             strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                         }
 
@@ -195,7 +195,7 @@ extension PCUserSubscription {
                     room.userStore.addOrMerge(user)
 
                     if roomUsersProgressCounter.incrementSuccessAndCheckIfFinished() {
-                        room.subscription?.delegate.usersUpdated()
+                        room.subscription?.delegate?.usersUpdated()
                         strongSelf.instance.logger.log("Users updated in room \(room.name)", logLevel: .verbose)
                     }
                 }
@@ -349,7 +349,7 @@ extension PCUserSubscription {
                 room.userIds.insert(addedOrMergedUser.id)
 
                 strongSelf.delegate.userJoinedRoom(room: room, user: addedOrMergedUser)
-                room.subscription?.delegate.userJoined(user: addedOrMergedUser)
+                room.subscription?.delegate?.userJoined(user: addedOrMergedUser)
                 strongSelf.instance.logger.log("User \(user.displayName) joined room: \(room.name)", logLevel: .verbose)
             }
         }
@@ -419,7 +419,7 @@ extension PCUserSubscription {
                 room.userStore.remove(id: user.id)
 
                 strongSelf.delegate.userLeftRoom(room: room, user: user)
-                room.subscription?.delegate.userLeft(user: user)
+                room.subscription?.delegate?.userLeft(user: user)
                 strongSelf.instance.logger.log("User \(user.displayName) left room: \(room.name)", logLevel: .verbose)
             }
         }
@@ -464,7 +464,7 @@ extension PCUserSubscription {
                 }
 
                 strongSelf.delegate.userStartedTyping(room: room, user: user)
-                room.subscription?.delegate.userStartedTyping(user: user)
+                room.subscription?.delegate?.userStartedTyping(user: user)
                 strongSelf.instance.logger.log("\(user.displayName) started typing in room \(room.name)", logLevel: .verbose)
             }
         }
@@ -509,7 +509,7 @@ extension PCUserSubscription {
                 }
 
                 strongSelf.delegate.userStoppedTyping(room: room, user: user)
-                room.subscription?.delegate.userStoppedTyping(user: user)
+                room.subscription?.delegate?.userStoppedTyping(user: user)
                 strongSelf.instance.logger.log("\(user.displayName) stopped typing in room \(room.name)", logLevel: .verbose)
             }
         }


### PR DESCRIPTION
### What?

This PR fixes the memory leak caused by strong references to `PCRoomDelegate`, `PCMessageSubscription` and `PCCursorSubscription` being retained.

More details can be found in #76.

----

CC @hamchapman