### PR TITLE
Cursors tests

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "pusher/pusher-platform-swift" "0.5.0"
 github "hamchapman/Mockingjay" "bf8fc0a2f9e3e473ae9b7d9c9211c406932d2eee"
 github "krzyzanowskim/CryptoSwift" "0.10.0"
+github "pusher/pusher-platform-swift" "0.5.0"

--- a/PusherChatkit.xcodeproj/project.pbxproj
+++ b/PusherChatkit.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		33D2A5AF1E39075100EA7549 /* ChatManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D2A5AD1E39074800EA7549 /* ChatManagerTests.swift */; };
 		33E3EBC7200E2368003D888D /* PPTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E3EBC6200E2368003D888D /* PPTypealiases.swift */; };
 		33EE67DD20F5176800B0F0AD /* TokenGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EE67DC20F5176800B0F0AD /* TokenGenerator.swift */; };
+		F2AA717520F7616000BC01DE /* CursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2AA717420F7616000BC01DE /* CursorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +125,7 @@
 		33D2A5AD1E39074800EA7549 /* ChatManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatManagerTests.swift; sourceTree = "<group>"; };
 		33E3EBC6200E2368003D888D /* PPTypealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPTypealiases.swift; sourceTree = "<group>"; };
 		33EE67DC20F5176800B0F0AD /* TokenGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenGenerator.swift; sourceTree = "<group>"; };
+		F2AA717420F7616000BC01DE /* CursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CursorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,7 +152,6 @@
 			children = (
 				33831C8B1A9CF61600B124F1 /* Sources */,
 				33BB995C1D21225B00B25C2A /* Tests */,
-				33831C8A1A9CF61600B124F1 /* Products */,
 				42D29A655054030A9B238900 /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -162,6 +163,7 @@
 				33831C941A9CF61600B124F1 /* PusherChatkitTests.xctest */,
 			);
 			name = Products;
+			path = ..;
 			sourceTree = "<group>";
 		};
 		33831C8B1A9CF61600B124F1 /* Sources */ = {
@@ -226,13 +228,15 @@
 			isa = PBXGroup;
 			children = (
 				33D0394D20F6593200B5D87A /* Config */,
+				33D0394C20F650F900B5D87A /* Helpers */,
+				33831C8A1A9CF61600B124F1 /* Products */,
+				33D0394E20F6594600B5D87A /* Supporting Files */,
+				F2AA717420F7616000BC01DE /* CursorTests.swift */,
 				339768F420F4ED2F00BCB10B /* UserSubscriptionTests.swift */,
 				333D861720F4A97100734402 /* CurrentUserTests.swift */,
 				33D2A5AD1E39074800EA7549 /* ChatManagerTests.swift */,
 				337C0C9520615A6600BB977A /* TokenProviderTests.swift */,
 				33BC080F209A1765001DB5F9 /* DefaultsTests.swift */,
-				33D0394C20F650F900B5D87A /* Helpers */,
-				33D0394E20F6594600B5D87A /* Supporting Files */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -448,6 +452,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				339768F320F4CC6700BCB10B /* TestConfig.swift in Sources */,
+				F2AA717520F7616000BC01DE /* CursorTests.swift in Sources */,
 				339768F720F4EEEC00BCB10B /* Helpers.swift in Sources */,
 				337C0C9620615A6600BB977A /* TokenProviderTests.swift in Sources */,
 				33D2A5AF1E39075100EA7549 /* ChatManagerTests.swift in Sources */,

--- a/Tests/CursorTests.swift
+++ b/Tests/CursorTests.swift
@@ -2,65 +2,99 @@ import XCTest
 import PusherPlatform
 @testable import PusherChatkit
 
-func testUser(userId: String) -> ChatManager {
-    return ChatManager(
-        instanceLocator: testInstanceLocator,
-        tokenProvider: PCTokenProvider(url: testInstanceTokenProviderURL),
-        userId: userId,
-        logger: TestLogger()
-    )
-}
+var alice: PCCurrentUser?
+var bob: PCCurrentUser?
+var roomId: Int?
+var doneSetUp = false
 
 class CursorTests: XCTestCase {
-    var aliceManager: ChatManager?
-    var bobManager: ChatManager?
-    var room: PCRoom?
-    
-    // Currently these tests only pass if the users "alice" and "bob" already exist.
     override func setUp() {
-        let ex = expectation(description: "Room is created")
-        if aliceManager == nil {
-            aliceManager = testUser(userId: "alice")
-        }
-        if bobManager == nil {
-            aliceManager = testUser(userId: "bob")
-        }
-        if room == nil {
-            aliceManager?.connect(delegate: TestingChatManagerDelegate()) { alice, error in
-                XCTAssertNil(error)
-                
-                alice?.createRoom(name: "Alice's room") { r, error in
-                    XCTAssertNil(error)
-                    
-                    self.room = r
-                    
-                    ex.fulfill()
-                }
-            }
-        } else {
-            ex.fulfill()
-        }
         super.setUp()
-        waitForExpectations(timeout: 5)
+
+        if !doneSetUp {
+            alice = user(id: "alice")
+            bob = user(id: "bob")
+            roomId = createRoom(user: user(id: "alice"), roomName: "mushroom", addUserIds: ["bob"]).id
+            doneSetUp = true
+        }
     }
-    
+
     func testOwnReadCursorUndefinedIfNotSet() {
-        let ex = expectation(description: "Get empty cursor after connection")
-        
-        aliceManager?.connect(delegate: TestingChatManagerDelegate()) { alice, error in
+        let cursor = try! user(id: "alice").readCursor(roomId: roomId!)
+        XCTAssertNil(cursor)
+    }
+
+    // TODO own read cursor?
+
+    func testNewReadCursorHook() {
+        class AliceRoomDelegate: NSObject, PCRoomDelegate {
+            let ex: XCTestExpectation
+
+            init(expectation: XCTestExpectation) {
+                ex = expectation
+            }
+
+            func newCursor(cursor: PCCursor) {
+                XCTAssertEqual(cursor.position, 42)
+                ex.fulfill()
+            }
+        }
+
+        let ex = expectation(description: "received new read cursor")
+        let aliceRoomDelegate = AliceRoomDelegate(expectation: ex)
+        alice!.subscribeToRoom(
+            room: alice!.rooms.first(where: { $0.id == roomId! })!,
+            roomDelegate: aliceRoomDelegate
+        )
+
+        // TODO can we wait on the subscription to finish (without sleeping...)?
+        sleep(2)
+
+        bob?.setReadCursor(position: 42, roomId: roomId!) { error in
             XCTAssertNil(error)
-            XCTAssertNotNil(alice)
-            
-            let cursor = try! alice!.readCursor(roomId: self.room!.id)
-            
-            XCTAssertNil(cursor)
+        }
+
+        waitForExpectations(timeout: 50) // why doesn't this work?
+    }
+
+    func user(id: String, delegate: PCChatManagerDelegate = TestingChatManagerDelegate()) -> PCCurrentUser {
+        var user: PCCurrentUser?
+
+        let ex = expectation(description: "connected as user with ID \(id)")
+
+        let chatManager = ChatManager(
+            instanceLocator: testInstanceLocator,
+            tokenProvider: PCTokenProvider(url: testInstanceTokenProviderURL),
+            userId: id,
+            logger: TestLogger()
+        )
+
+        chatManager.connect(delegate: delegate) { u, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(u)
+
+            user = u
             ex.fulfill()
         }
-        
+
         waitForExpectations(timeout: 5)
+        return user!
     }
-    
-    func testSomethingElse() {
-        print("TESTING SOMETHING ELSE!")
+
+    func createRoom(user: PCCurrentUser, roomName: String, addUserIds: [String] = []) -> PCRoom {
+        var room: PCRoom?
+
+        let ex = expectation(description: "created room with name  \(roomName)")
+
+        user.createRoom(name: roomName, addUserIds: addUserIds) { r, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(r)
+
+            room = r
+            ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+        return room!
     }
 }

--- a/Tests/CursorTests.swift
+++ b/Tests/CursorTests.swift
@@ -2,9 +2,9 @@ import XCTest
 import PusherPlatform
 @testable import PusherChatkit
 
-var alice: PCCurrentUser?
-var bob: PCCurrentUser?
-var roomId: Int?
+var alice: PCCurrentUser!
+var bob: PCCurrentUser!
+var roomId: Int!
 
 class AliceRoomDelegate: NSObject, PCRoomDelegate {
     let ex: XCTestExpectation?
@@ -66,7 +66,7 @@ class CursorTests: XCTestCase {
     }
 
     func testOwnReadCursorUndefinedIfNotSet() {
-        let cursor = try! alice?.readCursor(roomId: roomId!)
+        let cursor = try! alice.readCursor(roomId: roomId)
         XCTAssertNil(cursor)
     }
 
@@ -75,11 +75,11 @@ class CursorTests: XCTestCase {
     func testGetOwnReadCursor() {
         let ex = expectation(description: "got own read cursor")
 
-        alice?.setReadCursor(position: 42, roomId: roomId!) { error in
+        alice.setReadCursor(position: 42, roomId: roomId) { error in
             XCTAssertNil(error)
 
             sleep(1) // give the read cursor a chance to propagate down the connection
-            let cursor = try! alice!.readCursor(roomId: roomId!)
+            let cursor = try! alice.readCursor(roomId: roomId)
             XCTAssertEqual(cursor?.position, 42)
 
             ex.fulfill()
@@ -92,14 +92,14 @@ class CursorTests: XCTestCase {
         let ex = expectation(description: "received new read cursor")
 
         let aliceRoomDelegate = AliceRoomDelegate(expectation: ex)
-        alice!.subscribeToRoom(
-            room: alice!.rooms.first(where: { $0.id == roomId! })!,
+        alice.subscribeToRoom(
+            room: alice.rooms.first(where: { $0.id == roomId })!,
             roomDelegate: aliceRoomDelegate
         )
 
-        sleep(1)
+        sleep(1) // TODO remove once we can wait on the completion of subscribeToRoom
 
-        bob?.setReadCursor(position: 42, roomId: roomId!) { error in
+        bob.setReadCursor(position: 42, roomId: roomId) { error in
             XCTAssertNil(error)
         }
 
@@ -107,13 +107,13 @@ class CursorTests: XCTestCase {
     }
 
     func testGetAnotherUsersReadCursorBeforeSubscribingFails() {
-        let ex = expectation(description: "got another users read cursor fails")
+        let ex = expectation(description: "get another users read cursor fails")
 
-        bob?.setReadCursor(position: 42, roomId: roomId!) { error in
+        bob.setReadCursor(position: 42, roomId: roomId) { error in
             XCTAssertNil(error)
 
             do {
-                let _ = try alice!.readCursor(roomId: roomId!, userId: "bob")
+                let _ = try alice.readCursor(roomId: roomId, userId: "bob")
             } catch let error {
                 switch error {
                 case PCCurrentUserError.noSubscriptionToRoom:
@@ -128,21 +128,21 @@ class CursorTests: XCTestCase {
     }
 
     func testGetAnotherUsersReadCursor() {
-        let ex = expectation(description: "got another users read cursor fails")
+        let ex = expectation(description: "got another users read cursor")
 
         let aliceRoomDelegate = AliceRoomDelegate()
-        alice!.subscribeToRoom(
-            room: alice!.rooms.first(where: { $0.id == roomId! })!,
+        alice.subscribeToRoom(
+            room: alice.rooms.first(where: { $0.id == roomId })!,
             roomDelegate: aliceRoomDelegate
         )
 
         sleep(1)
 
-        bob?.setReadCursor(position: 42, roomId: roomId!) { error in
+        bob.setReadCursor(position: 42, roomId: roomId) { error in
             XCTAssertNil(error)
 
             sleep(1) // give the read cursor a chance to propagate down the connection
-            let cursor = try! alice!.readCursor(roomId: roomId!, userId: "bob")
+            let cursor = try! alice.readCursor(roomId: roomId, userId: "bob")
             XCTAssertEqual(cursor?.position, 42)
 
             ex.fulfill()
@@ -152,7 +152,7 @@ class CursorTests: XCTestCase {
     }
 
     func user(id: String, delegate: PCChatManagerDelegate = TestingChatManagerDelegate()) -> PCCurrentUser {
-        var user: PCCurrentUser?
+        var user: PCCurrentUser!
 
         let ex = expectation(description: "connected as user with ID \(id)")
 
@@ -172,11 +172,11 @@ class CursorTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 5)
-        return user!
+        return user
     }
 
     func createRoom(user: PCCurrentUser, roomName: String, addUserIds: [String] = []) -> PCRoom {
-        var room: PCRoom?
+        var room: PCRoom!
 
         let ex = expectation(description: "created room with name  \(roomName)")
 
@@ -189,6 +189,6 @@ class CursorTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 5)
-        return room!
+        return room
     }
 }

--- a/Tests/CursorTests.swift
+++ b/Tests/CursorTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import PusherPlatform
+@testable import PusherChatkit
+
+func testUser(userId: String) -> ChatManager {
+    return ChatManager(
+        instanceLocator: testInstanceLocator,
+        tokenProvider: PCTokenProvider(url: testInstanceTokenProviderURL),
+        userId: userId,
+        logger: TestLogger()
+    )
+}
+
+class CursorTests: XCTestCase {
+    var aliceManager: ChatManager?
+    var bobManager: ChatManager?
+    var room: PCRoom?
+    
+    // Currently these tests only pass if the users "alice" and "bob" already exist.
+    override func setUp() {
+        let ex = expectation(description: "Room is created")
+        if aliceManager == nil {
+            aliceManager = testUser(userId: "alice")
+        }
+        if bobManager == nil {
+            aliceManager = testUser(userId: "bob")
+        }
+        if room == nil {
+            aliceManager?.connect(delegate: TestingChatManagerDelegate()) { alice, error in
+                XCTAssertNil(error)
+                
+                alice?.createRoom(name: "Alice's room") { r, error in
+                    XCTAssertNil(error)
+                    
+                    self.room = r
+                    
+                    ex.fulfill()
+                }
+            }
+        } else {
+            ex.fulfill()
+        }
+        super.setUp()
+        waitForExpectations(timeout: 5)
+    }
+    
+    func testOwnReadCursorUndefinedIfNotSet() {
+        let ex = expectation(description: "Get empty cursor after connection")
+        
+        aliceManager?.connect(delegate: TestingChatManagerDelegate()) { alice, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(alice)
+            
+            let cursor = try! alice!.readCursor(roomId: self.room!.id)
+            
+            XCTAssertNil(cursor)
+            ex.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5)
+    }
+    
+    func testSomethingElse() {
+        print("TESTING SOMETHING ELSE!")
+    }
+}


### PR DESCRIPTION
### What?

Tests the existing behaviour. There's no hook for receiving changes to your own read cursors if you're not subscribed to the room, I'll stick a card in triage.

----

CC @hamchapman
