### PR TITLE
sync connectAsUser and createRoom tests

### DIFF
--- a/Tests/CursorTests.swift
+++ b/Tests/CursorTests.swift
@@ -60,9 +60,16 @@ class CursorTests: XCTestCase {
 
         waitForExpectations(timeout: 10)
 
-        alice = user(id: "alice")
-        bob = user(id: "bob")
-        roomId = createRoom(user: user(id: "alice"), roomName: "mushroom", addUserIds: ["bob"]).id
+        alice = try! connectAsUser(id: "alice")
+        bob = try! connectAsUser(id: "bob")
+
+        let room = try! createRoom(
+            user: alice,
+            roomName: "mushroom",
+            addUserIds: ["bob"]
+        )
+
+        roomId = room.id
     }
 
     func testOwnReadCursorUndefinedIfNotSet() {
@@ -149,46 +156,5 @@ class CursorTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 5)
-    }
-
-    func user(id: String, delegate: PCChatManagerDelegate = TestingChatManagerDelegate()) -> PCCurrentUser {
-        var user: PCCurrentUser!
-
-        let ex = expectation(description: "connected as user with ID \(id)")
-
-        let chatManager = ChatManager(
-            instanceLocator: testInstanceLocator,
-            tokenProvider: PCTokenProvider(url: testInstanceTokenProviderURL),
-            userId: id,
-            logger: TestLogger()
-        )
-
-        chatManager.connect(delegate: delegate) { u, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(u)
-
-            user = u
-            ex.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
-        return user
-    }
-
-    func createRoom(user: PCCurrentUser, roomName: String, addUserIds: [String] = []) -> PCRoom {
-        var room: PCRoom!
-
-        let ex = expectation(description: "created room with name  \(roomName)")
-
-        user.createRoom(name: roomName, addUserIds: addUserIds) { r, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(r)
-
-            room = r
-            ex.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
-        return room
     }
 }

--- a/Tests/Helpers/Helpers.swift
+++ b/Tests/Helpers/Helpers.swift
@@ -177,3 +177,61 @@ enum ChatkitService {
         }
     }
 }
+
+func connectAsUser(
+    id: String,
+    delegate: PCChatManagerDelegate = TestingChatManagerDelegate()
+) throws -> PCCurrentUser {
+    var user: PCCurrentUser!
+    var error: Error?
+
+    let group = DispatchGroup()
+    group.enter()
+
+    let chatManager = ChatManager(
+        instanceLocator: testInstanceLocator,
+        tokenProvider: PCTokenProvider(url: testInstanceTokenProviderURL),
+        userId: id,
+        logger: TestLogger()
+    )
+
+    chatManager.connect(delegate: delegate) { u, e in
+        user = u
+        error = e
+        group.leave()
+    }
+
+    group.wait()
+
+    if let e = error {
+        throw e
+    }
+
+    return user
+}
+
+func createRoom(
+    user: PCCurrentUser,
+    roomName: String,
+    addUserIds: [String] = []
+) throws -> PCRoom {
+    var room: PCRoom!
+    var error: Error?
+
+    let group = DispatchGroup()
+    group.enter()
+
+    user.createRoom(name: roomName, addUserIds: addUserIds) { r, e in
+        room = r
+        error = e
+        group.leave()
+    }
+
+    group.wait()
+
+    if let e = error {
+        throw e
+    }
+
+    return room
+}


### PR DESCRIPTION
### What?

Moved the synchronous connection and room creation helpers I was using for the cursors tests in to the test helpers file so we can re-use them, and converted to use a `DispatchGroup` instead of relying on XCTest's expectations.

### Why?

So we can re-use them elsewhere, and to discuss the style.

If you think this is a good idea, we should maybe write all the helpers in a synchronous style? Otherwise I'll rewrite these ones in an async style and update the tests accordingly.

----

CC @hamchapman
