### PR TITLE
Move cursor tests variables inside tests class

### DIFF
--- a/PusherChatkit.xcodeproj/project.pbxproj
+++ b/PusherChatkit.xcodeproj/project.pbxproj
@@ -228,15 +228,15 @@
 			isa = PBXGroup;
 			children = (
 				33D0394D20F6593200B5D87A /* Config */,
-				33D0394C20F650F900B5D87A /* Helpers */,
-				33831C8A1A9CF61600B124F1 /* Products */,
-				33D0394E20F6594600B5D87A /* Supporting Files */,
-				F2AA717420F7616000BC01DE /* CursorTests.swift */,
-				339768F420F4ED2F00BCB10B /* UserSubscriptionTests.swift */,
-				333D861720F4A97100734402 /* CurrentUserTests.swift */,
 				33D2A5AD1E39074800EA7549 /* ChatManagerTests.swift */,
+				333D861720F4A97100734402 /* CurrentUserTests.swift */,
+				339768F420F4ED2F00BCB10B /* UserSubscriptionTests.swift */,
+				F2AA717420F7616000BC01DE /* CursorTests.swift */,
 				337C0C9520615A6600BB977A /* TokenProviderTests.swift */,
 				33BC080F209A1765001DB5F9 /* DefaultsTests.swift */,
+				33D0394C20F650F900B5D87A /* Helpers */,
+				33D0394E20F6594600B5D87A /* Supporting Files */,
+				33831C8A1A9CF61600B124F1 /* Products */,
 			);
 			path = Tests;
 			sourceTree = "<group>";

--- a/Tests/CursorTests.swift
+++ b/Tests/CursorTests.swift
@@ -2,26 +2,26 @@ import XCTest
 import PusherPlatform
 @testable import PusherChatkit
 
-var alice: PCCurrentUser!
-var bob: PCCurrentUser!
-var roomId: Int!
+class CursorTests: XCTestCase {
+    var alice: PCCurrentUser!
+    var bob: PCCurrentUser!
+    var roomId: Int!
 
-class AliceRoomDelegate: NSObject, PCRoomDelegate {
-    let ex: XCTestExpectation?
+    class AliceRoomDelegate: NSObject, PCRoomDelegate {
+        let ex: XCTestExpectation?
 
-    init(expectation: XCTestExpectation? = nil) {
-        ex = expectation
-    }
+        init(expectation: XCTestExpectation? = nil) {
+            ex = expectation
+        }
 
-    func newCursor(cursor: PCCursor) {
-        XCTAssertEqual(cursor.position, 42)
-        if let e = ex {
-            e.fulfill()
+        func newCursor(cursor: PCCursor) {
+            XCTAssertEqual(cursor.position, 42)
+            if let e = ex {
+                e.fulfill()
+            }
         }
     }
-}
 
-class CursorTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
@@ -86,7 +86,7 @@ class CursorTests: XCTestCase {
             XCTAssertNil(error)
 
             sleep(1) // give the read cursor a chance to propagate down the connection
-            let cursor = try! alice.readCursor(roomId: roomId)
+            let cursor = try! self.alice.readCursor(roomId: self.roomId)
             XCTAssertEqual(cursor?.position, 42)
 
             ex.fulfill()
@@ -120,7 +120,7 @@ class CursorTests: XCTestCase {
             XCTAssertNil(error)
 
             do {
-                let _ = try alice.readCursor(roomId: roomId, userId: "bob")
+                let _ = try self.alice.readCursor(roomId: self.roomId, userId: "bob")
             } catch let error {
                 switch error {
                 case PCCurrentUserError.noSubscriptionToRoom:
@@ -149,7 +149,7 @@ class CursorTests: XCTestCase {
             XCTAssertNil(error)
 
             sleep(1) // give the read cursor a chance to propagate down the connection
-            let cursor = try! alice.readCursor(roomId: roomId, userId: "bob")
+            let cursor = try! self.alice.readCursor(roomId: self.roomId, userId: "bob")
             XCTAssertEqual(cursor?.position, 42)
 
             ex.fulfill()


### PR DESCRIPTION
### What?

(Ignore the changes to `project.pbxproj`)

Move `alice`, `bob` and `roomId` inside the `CursorTests` class so that they are isolated from other tests.

### Why?

Keep tests isolated.


----

CC @hamchapman