### PR TITLE
attachmentType -> attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - All `PCMessage`s must have a `text` property
 - `subscribeToRoom` now has a (required) completion handler of type
   `PCErrorCompletionHandler`
+- `sendMessage` paramer `attachmentType` renamed to `attachment`
 
 ## [0.8.4](https://github.com/pusher/chatkit-swift/compare/0.8.3...0.8.4) - 2018-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - All `PCMessage`s must have a `text` property
 - `subscribeToRoom` now has a (required) completion handler of type
   `PCErrorCompletionHandler`
-- `sendMessage` paramer `attachmentType` renamed to `attachment`
+- `sendMessage` parameter `attachmentType` renamed to `attachment`
 
 ## [0.8.4](https://github.com/pusher/chatkit-swift/compare/0.8.3...0.8.4) - 2018-05-26
 

--- a/ChatkitiOSExample/ChatkitiOSExample/ViewController.swift
+++ b/ChatkitiOSExample/ChatkitiOSExample/ViewController.swift
@@ -59,8 +59,8 @@ class ViewController: UIViewController {
 //                currentUser.sendMessage(
 //                    roomId: currentUser.rooms.last!.id,
 //                    text: "Just a message with an attachment",
-//                    attachmentType: .fileURL(imageURL, name: "cucas.jpg")
-////                    attachmentType: .link("https://i.giphy.com/RpByGPT5VlZiE.gif", type: "image")
+//                    attachment: .fileURL(imageURL, name: "cucas.jpg")
+////                    attachment: .link("https://i.giphy.com/RpByGPT5VlZiE.gif", type: "image")
 //                ) { messageId, err in
 //                    guard err == nil else {
 //                        print("Error sending message \(err!.localizedDescription)")

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -605,7 +605,7 @@ public final class PCCurrentUser {
     public func sendMessage(
         roomId: Int,
         text: String,
-        attachmentType: PCAttachmentType? = nil,
+        attachment: PCAttachmentType? = nil,
         completionHandler: @escaping (Int?, Error?) -> Void
     ) {
         var messageObject: [String: Any] = [
@@ -613,16 +613,16 @@ public final class PCCurrentUser {
             "text": text
         ]
 
-        guard let attachmentType = attachmentType else {
+        guard let attachment = attachment else {
             sendMessage(messageObject, roomId: roomId, completionHandler: completionHandler)
             return
         }
-        
-        switch attachmentType {
+
+        switch attachment {
         case .fileData(_, _), .fileURL(_, _):
             uploadAttachmentAndSendMessage(
                 messageObject,
-                attachment: attachmentType,
+                attachment: attachment,
                 roomId: roomId,
                 completionHandler: completionHandler
             )

--- a/Tests/MessageTests.swift
+++ b/Tests/MessageTests.swift
@@ -284,7 +284,7 @@ class MessagesTests: XCTestCase {
                         alice!.sendMessage(
                             roomId: self.roomId,
                             text: "see attached",
-                            attachmentType: .link(veryImportantImage, type: "image")
+                            attachment: .link(veryImportantImage, type: "image")
                         ) { _, err in
                             XCTAssertNil(err)
                         }
@@ -345,7 +345,7 @@ class MessagesTests: XCTestCase {
 //                alice!.sendMessage(
 //                    roomId: self.roomId,
 //                    text: "see attached",
-//                    attachmentType: .fileURL(
+//                    attachment: .fileURL(
 //                        URL(fileURLWithPath: veryImportantImage),
 //                        name: "test-image.gif"
 //                    )


### PR DESCRIPTION
Having a type called `PCAttachmentType` still feels a bit wrong, but I think renaming the parameter at least is an improvement.

[mimir](https://github.com/pusher/mimir/pull/440)

----

CC @hamchapman
