### PR TITLE
order fetch messages by increasing id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `subscribeToRoom` now has a (required) completion handler of type
   `PCErrorCompletionHandler`
 - `sendMessage` parameter `attachmentType` renamed to `attachment`
+- The ordering of messages returned by `fetchMessagesFromRoom` is now from
+  oldest to newest
 
 ## [0.8.4](https://github.com/pusher/chatkit-swift/compare/0.8.3...0.8.4) - 2018-05-26
 

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -954,7 +954,12 @@ public final class PCCurrentUser {
 
                             messages.append(message) {
                                 if progressCounter.incrementSuccessAndCheckIfFinished() {
-                                    completionHandler(messages.underlyingArray.sorted(by: { $0.id > $1.id }), nil)
+                                    completionHandler(
+                                        messages.underlyingArray.sorted(
+                                            by: { $0.id < $1.id }
+                                        ),
+                                        nil
+                                    )
                                 }
                             }
                         }

--- a/Tests/MessageTests.swift
+++ b/Tests/MessageTests.swift
@@ -86,7 +86,7 @@ class MessagesTests: XCTestCase {
 
                 XCTAssertEqual(
                     messages!.map { $0.text },
-                    ["ho", "hi", "hey", "hello"]
+                    ["hello", "hey", "hi", "ho"]
                 )
 
                 XCTAssert(messages!.all { $0.sender.id == "alice" })
@@ -113,7 +113,7 @@ class MessagesTests: XCTestCase {
             ) { messages, err in
                 XCTAssertNil(err)
 
-                XCTAssertEqual(messages!.map { $0.text }, ["ho", "hi"])
+                XCTAssertEqual(messages!.map { $0.text }, ["hi", "ho"])
                 XCTAssert(messages!.all { $0.sender.id == "alice" })
                 XCTAssert(messages!.all { $0.sender.name == "Alice" })
                 XCTAssert(messages!.all { $0.room.id == self.roomId })
@@ -125,7 +125,7 @@ class MessagesTests: XCTestCase {
                 ) { messages, err in
                     XCTAssertNil(err)
 
-                    XCTAssertEqual(messages!.map { $0.text }, ["hey", "hello"])
+                    XCTAssertEqual(messages!.map { $0.text }, ["hello", "hey"])
                     XCTAssert(messages!.all { $0.sender.id == "alice" })
                     XCTAssert(messages!.all { $0.sender.name == "Alice" })
                     XCTAssert(messages!.all { $0.room.id == self.roomId })
@@ -142,10 +142,10 @@ class MessagesTests: XCTestCase {
     func testSubscribeToRoomAndFetchInitial() {
         let ex = expectation(description: "subscribe and get initial messages")
 
-        var expectedMessageTexts = ["ho", "hi", "hey", "hello"]
+        var expectedMessageTexts = ["hello", "hey", "hi", "ho"]
 
         let bobRoomDelegate = TestingRoomDelegate(newMessage: { message in
-            XCTAssertEqual(message.text, expectedMessageTexts.popLast()!)
+            XCTAssertEqual(message.text, expectedMessageTexts.removeFirst())
             XCTAssertEqual(message.sender.id, "alice")
             XCTAssertEqual(message.sender.name, "Alice")
             XCTAssertEqual(message.room.id, self.roomId)


### PR DESCRIPTION
To match the Javascript SDK...

*But* I do see the logic in having it go the other way 🤔 When you're paginating it's certainly nicer to have the newest items first. Maybe we should change it in the js sdk instead? wdyt @hamchapman?
