### PR TITLE
Get users by ids v2

### DIFF
--- a/Sources/PCGlobalUserStore.swift
+++ b/Sources/PCGlobalUserStore.swift
@@ -100,11 +100,9 @@ public final class PCGlobalUserStore {
             return
         }
 
-        let userIdsString = userIds.joined(separator: ",")
-
         let path = "/users_by_ids"
         let generalRequest = PPRequestOptions(method: HTTPMethod.GET.rawValue, path: path)
-        generalRequest.addQueryItems([URLQueryItem(name: "user_ids", value: userIdsString)])
+        generalRequest.addQueryItems(userIds.map{URLQueryItem(name: "id", value: $0)})
 
         // We want this to complete quickly, whether it succeeds or not
         generalRequest.retryStrategy = PPDefaultRetryStrategy(maxNumberOfAttempts: 1)


### PR DESCRIPTION
### What?

Get users by ids now takes query parameters in a more sane way with repeating query parameters that get interpreted as an array on the server side.

### Why?

because `,` could be a valid user id, which leads to all sorts of disgraces.

----

CC @hamchapman
