### PR TITLE
Timers to repeaters

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "pusher/pusher-platform-swift" ~> 0.5.0
+github "pusher/pusher-platform-swift" ~> 0.6.1
 
 # you'll need something like this if working locally and you want
 # to test changes to pusher-platform-swift

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "hamchapman/Mockingjay" "90156b01840e39549a451f97fc5b611ecf060d8f"
 github "krzyzanowskim/CryptoSwift" "0.11.0"
-github "pusher/pusher-platform-swift" "0.5.0"
+github "pusher/pusher-platform-swift" "0.6.1"

--- a/PusherChatkit.podspec
+++ b/PusherChatkit.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'Sources/*.swift'
 
-  s.dependency 'PusherPlatform', '~> 0.5.0'
+  s.dependency 'PusherPlatform', '~> 0.6.1'
 
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.11'

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -32,16 +32,15 @@ import PusherPlatform
     ) {
         let splitInstance = instanceLocator.split(separator: ":")
         let cluster = splitInstance[1]
-        let sharedBaseClient = baseClient ?? PCBaseClient(host: "\(cluster).pusherplatform.io")
-        sharedBaseClient.logger = logger
 
         self.logger = logger
 
         let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "0.10.0")
+        let sharedBaseClient = baseClient ?? PCBaseClient(host: "\(cluster).pusherplatform.io", sdkInfo: sdkInfo)
+        sharedBaseClient.logger = logger
 
         let sharedInstanceOptions = PCSharedInstanceOptions(
             locator: instanceLocator,
-            sdkInfo: sdkInfo,
             tokenProvider: tokenProvider,
             baseClient: sharedBaseClient,
             logger: logger
@@ -238,9 +237,8 @@ import PusherPlatform
             locator: options.locator,
             serviceName: serviceName,
             serviceVersion: serviceVersion,
-            sdkInfo: options.sdkInfo,
-            tokenProvider: options.tokenProvider,
             client: options.baseClient,
+            tokenProvider: options.tokenProvider,
             logger: options.logger
         )
     }

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -853,8 +853,7 @@ public final class PCCurrentUser {
             method: HTTPMethod.SUBSCRIBE.rawValue,
             path: path,
             queryItems: [
-                URLQueryItem(name: "user_id", value: self.id),
-                URLQueryItem(name: "message_limit", value: String(messageLimit)),
+                URLQueryItem(name: "message_limit", value: String(messageLimit))
             ]
         )
 

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -1109,28 +1109,3 @@ public enum PCRoomMessageFetchDirection: String {
 public typealias PCErrorCompletionHandler = (Error?) -> Void
 public typealias PCRoomCompletionHandler = (PCRoom?, Error?) -> Void
 public typealias PCRoomsCompletionHandler = ([PCRoom]?, Error?) -> Void
-
-// Takes an `inner` completion handler of type `PCErrorCompletionHandler`,
-// returns another completion handler of the same type that calls the inner
-// completion handler after being called itself `steps` times. Returns the last
-// error, if any.
-func steppedCompletionHandler(
-    steps: Int,
-    inner: @escaping PCErrorCompletionHandler,
-    dispatchQueue: DispatchQueue
-) -> PCErrorCompletionHandler {
-    var error: Error?
-
-    let group = DispatchGroup()
-
-    for _ in 0..<steps {
-        group.enter()
-    }
-
-    group.notify(queue: dispatchQueue) { inner(error) }
-
-    return { err in
-        error = err
-        group.leave()
-    }
-}

--- a/Sources/PCSharedInstanceOptions.swift
+++ b/Sources/PCSharedInstanceOptions.swift
@@ -3,7 +3,6 @@ import PusherPlatform
 
 struct PCSharedInstanceOptions {
     let locator: String
-    let sdkInfo: PPSDKInfo
     let tokenProvider: PPTokenProvider
     let baseClient: PPBaseClient
     let logger: PPLogger

--- a/Tests/CursorTests.swift
+++ b/Tests/CursorTests.swift
@@ -62,7 +62,7 @@ class CursorTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: 15)
     }
 
     override func tearDown() {
@@ -95,7 +95,7 @@ class CursorTests: XCTestCase {
             ex.fulfill()
         }
 
-        waitForExpectations(timeout: 5)
+        waitForExpectations(timeout: 15)
     }
 
     func testNewReadCursorHook() {
@@ -119,7 +119,7 @@ class CursorTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 5)
+        waitForExpectations(timeout: 15)
     }
 
     func testGetAnotherUsersReadCursorBeforeSubscribingFails() {
@@ -140,7 +140,7 @@ class CursorTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 5)
+        waitForExpectations(timeout: 15)
     }
 
     func testGetAnotherUsersReadCursor() {
@@ -165,6 +165,6 @@ class CursorTests: XCTestCase {
         }
 
 
-        waitForExpectations(timeout: 5)
+        waitForExpectations(timeout: 15)
     }
 }


### PR DESCRIPTION
### What?

* Bump pusher-platform-swift dependency to 0.6.1
* Use `PPRepeater`s in place of `NSTimer`s

### Why?

Bug fixes

----

CC @hamchapman
