### PR TITLE
Push notification fix

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "hamchapman/Mockingjay" "90156b01840e39549a451f97fc5b611ecf060d8f"
 github "krzyzanowskim/CryptoSwift" "0.13.1"
-github "pusher/beams-chatkit-swift" "1.2.3"
+github "pusher/beams-chatkit-swift" "1.2.4"
 github "pusher/pusher-platform-swift" "0.6.2"

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -1210,18 +1210,20 @@ extension PCCurrentUser {
         let chatkitBeamsTokenProvider = ChatkitBeamsTokenProvider(instance: self.chatkitBeamsTokenProviderInstance)
 
         pushNotifications.start(instanceId: self.instance.id, tokenProvider: chatkitBeamsTokenProvider)
-        pushNotifications.clearAllState { (error) in
+        pushNotifications.clearAllState { error in
             guard error == nil else {
                 return self.instance.logger.log("Error occured while clearing the state: \(error!)", logLevel: .error)
             }
 
             self.setUser()
         }
+
+        ChatManager.registerForRemoteNotifications()
     }
 
     private func setUser() {
         do {
-            try pushNotifications.setUserId(self.id, completion: { (error) in
+            try pushNotifications.setUserId(self.id, completion: { error in
                 guard error == nil else {
                     return self.instance.logger.log("Error occured while setting the user: \(error!)", logLevel: .error)
                 }


### PR DESCRIPTION
### What?

Ensure that `registerForRemoteNotifications()` is called after push notifications have been enabled, even if it has already been called

### Why?

To ensure that the `instanceId` is set for the push notifications SDK to be able to make the network call it needs to make.

----

CC @hamchapman
