### PR TITLE
Don't use 'userID/roomID' concatenated string for cursor store dictionary keys

### DIFF
--- a/Sources/PCCursorStore.swift
+++ b/Sources/PCCursorStore.swift
@@ -7,7 +7,7 @@ public final class PCCursorStore {
     let userStore: PCGlobalUserStore
     let basicCursorEnricher: PCBasicCursorEnricher
 
-    public var cursors: [String: PCCursor] = [:]
+    public var cursors: [PCCursorKey: PCCursor] = [:]
 
     public init(instance: Instance, roomStore: PCRoomStore, userStore: PCGlobalUserStore) {
         self.instance = instance
@@ -105,7 +105,12 @@ public final class PCCursorStore {
         )
     }
 
-    fileprivate func key(_ userID: String, _ roomID: String) -> String {
-        return "\(userID)/\(roomID)"
+    fileprivate func key(_ userID: String, _ roomID: String) -> PCCursorKey {
+        return PCCursorKey(userID: userID, roomID: roomID)
     }
+}
+
+public struct PCCursorKey: Hashable {
+    let userID: String
+    let roomID: String
 }


### PR DESCRIPTION
### What?

See title

### Why?

In preparation for allowing custom room IDs

----

CC @hamchapman