### PR TITLE
Encoded user IDs

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "hamchapman/Mockingjay" "90156b01840e39549a451f97fc5b611ecf060d8f"
 github "krzyzanowskim/CryptoSwift" "0.13.1"
 github "pusher/beams-chatkit-swift" "1.2.4"
-github "pusher/pusher-platform-swift" "0.6.3"
+github "pusher/pusher-platform-swift" "0.6.4"

--- a/PusherChatkit.xcodeproj/project.pbxproj
+++ b/PusherChatkit.xcodeproj/project.pbxproj
@@ -63,11 +63,12 @@
 		33EE67DD20F5176800B0F0AD /* TokenGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EE67DC20F5176800B0F0AD /* TokenGenerator.swift */; };
 		33F1FC2B210734A90083E05E /* test-image.gif in Resources */ = {isa = PBXBuildFile; fileRef = 33F1FC2A210734A90083E05E /* test-image.gif */; };
 		3704959A21876E3200DFC497 /* PCPresenceStateChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3704959921876E3200DFC497 /* PCPresenceStateChange.swift */; };
+		372641F921F7599A00B77869 /* ConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372641F821F7599A00B77869 /* ConnectionTests.swift */; };
+		374C814A21F0DA98008ECEBD /* PCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374C814921F0DA98008ECEBD /* PCDateFormatter.swift */; };
 		3762F45321A6ED20009D81CF /* ReconnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3762F45221A6ED20009D81CF /* ReconnectionTests.swift */; };
 		3775A83F21EE3845002297FA /* PCUpdatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3775A83E21EE3844002297FA /* PCUpdatable.swift */; };
 		3775A84121EE4177002297FA /* PCSubscriptionEventError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3775A84021EE4177002297FA /* PCSubscriptionEventError.swift */; };
 		37C526D621E3789B00309E3C /* InitialStateResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C526D521E3789B00309E3C /* InitialStateResult.swift */; };
-		374C814A21F0DA98008ECEBD /* PCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374C814921F0DA98008ECEBD /* PCDateFormatter.swift */; };
 		37DEF4D221A456C200F924EC /* RoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEF4D121A456C200F924EC /* RoomTests.swift */; };
 		37DEF4D621A4835900F924EC /* lol ? wut ?&...json in Resources */ = {isa = PBXBuildFile; fileRef = 37DEF4D521A4835900F924EC /* lol ? wut ?&...json */; };
 		37DEF4D721A485F400F924EC /* lol ? wut ?&...json in Resources */ = {isa = PBXBuildFile; fileRef = 37DEF4D521A4835900F924EC /* lol ? wut ?&...json */; };
@@ -149,11 +150,12 @@
 		33EE67DC20F5176800B0F0AD /* TokenGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenGenerator.swift; sourceTree = "<group>"; };
 		33F1FC2A210734A90083E05E /* test-image.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = "test-image.gif"; sourceTree = "<group>"; };
 		3704959921876E3200DFC497 /* PCPresenceStateChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCPresenceStateChange.swift; sourceTree = "<group>"; };
+		372641F821F7599A00B77869 /* ConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionTests.swift; sourceTree = "<group>"; };
+		374C814921F0DA98008ECEBD /* PCDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCDateFormatter.swift; sourceTree = "<group>"; };
 		3762F45221A6ED20009D81CF /* ReconnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectionTests.swift; sourceTree = "<group>"; };
 		3775A83E21EE3844002297FA /* PCUpdatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCUpdatable.swift; sourceTree = "<group>"; };
 		3775A84021EE4177002297FA /* PCSubscriptionEventError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCSubscriptionEventError.swift; sourceTree = "<group>"; };
 		37C526D521E3789B00309E3C /* InitialStateResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialStateResult.swift; sourceTree = "<group>"; };
-		374C814921F0DA98008ECEBD /* PCDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCDateFormatter.swift; sourceTree = "<group>"; };
 		37DEF4D121A456C200F924EC /* RoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTests.swift; sourceTree = "<group>"; };
 		37DEF4D521A4835900F924EC /* lol ? wut ?&...json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "lol ? wut ?&...json"; sourceTree = "<group>"; };
 		A14B8C3B2191AD1D0039AD5D /* ChatkitBeamsTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatkitBeamsTokenProvider.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				33D0394D20F6593200B5D87A /* Config */,
 				33D0394C20F650F900B5D87A /* Helpers */,
 				33D2A5AD1E39074800EA7549 /* ChatManagerTests.swift */,
+				372641F821F7599A00B77869 /* ConnectionTests.swift */,
 				333D861720F4A97100734402 /* CurrentUserTests.swift */,
 				F2AA717420F7616000BC01DE /* CursorTests.swift */,
 				33BC080F209A1765001DB5F9 /* DefaultsTests.swift */,
@@ -535,6 +538,7 @@
 				F2AA717920F8FBA400BC01DE /* TypingIndicatorTests.swift in Sources */,
 				F2665DEE20FDEE56002A0A3D /* PresenceTests.swift in Sources */,
 				33D2A5AF1E39075100EA7549 /* ChatManagerTests.swift in Sources */,
+				372641F921F7599A00B77869 /* ConnectionTests.swift in Sources */,
 				339768F520F4ED2F00BCB10B /* UserSubscriptionTests.swift in Sources */,
 				33AF440820FC922F00336710 /* RoomMembershipTests.swift in Sources */,
 				333D861820F4A97200734402 /* CurrentUserTests.swift in Sources */,

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -90,14 +90,14 @@ import NotificationCenter
         )
 
         self.connectionCoordinator = PCConnectionCoordinator(logger: logger)
+        self.userID = userID
+        let pathUserID = pathFriendlyVersion(of: userID)
+        self.pathFriendlyUserID = pathUserID
 
         if let tokenProvider = tokenProvider as? PCTokenProvider {
-            tokenProvider.userID = userID
+            tokenProvider.userID = pathUserID
             tokenProvider.logger = logger
         }
-
-        self.userID = userID
-        self.pathFriendlyUserID = pathFriendlyVersion(of: userID)
     }
 
     public func connect(

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -91,11 +91,10 @@ import NotificationCenter
 
         self.connectionCoordinator = PCConnectionCoordinator(logger: logger)
         self.userID = userID
-        let pathUserID = pathFriendlyVersion(of: userID)
-        self.pathFriendlyUserID = pathUserID
+        self.pathFriendlyUserID = pathFriendlyVersion(of: userID)
 
         if let tokenProvider = tokenProvider as? PCTokenProvider {
-            tokenProvider.userID = pathUserID
+            tokenProvider.userID = userID
             tokenProvider.logger = logger
         }
     }

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -272,7 +272,6 @@ import NotificationCenter
 
     // TODO: Maybe we need some sort of ChatManagerConnectionState?
     public func disconnect() {
-        self.logger.log("Disconnect called", logLevel: .verbose)
         currentUser?.userSubscription?.end()
         currentUser?.userSubscription = nil
         currentUser?.presenceSubscription?.end()

--- a/Sources/PCTokenProvider.swift
+++ b/Sources/PCTokenProvider.swift
@@ -80,6 +80,7 @@ public final class PCTokenProvider: PPTokenProvider {
             },
             retryStrategy: self.retryStrategy
         )
+        tokenProvider.logger = self.logger
 
         self.internalTokenProvider = tokenProvider
         return tokenProvider

--- a/Sources/PCTokenProvider.swift
+++ b/Sources/PCTokenProvider.swift
@@ -4,7 +4,16 @@ import PusherPlatform
 public final class PCTokenProvider: PPTokenProvider {
     public let url: String
     public let requestInjector: ((PCTokenProviderRequest) -> PCTokenProviderRequest)?
-    public var userID: String? = nil
+    public var userID: String? = nil {
+        willSet {
+            guard newValue != nil else {
+                return
+            }
+            self.pathFriendUserID = pathFriendlyVersion(of: newValue!)
+        }
+    }
+
+    var pathFriendUserID: String? = nil
 
     var fetchingToken: Bool = false
     var queuedTokenRecipients: [(PPTokenProviderResult) -> Void] = []
@@ -68,7 +77,7 @@ public final class PCTokenProvider: PPTokenProvider {
                     return req
                 }
 
-                guard let userID = strongSelf.userID else {
+                guard let userID = strongSelf.pathFriendUserID else {
                     return strongSelf.requestInjector != nil ? strongSelf.requestInjector!(req) : req
                 }
 

--- a/Tests/ConnectionTests.swift
+++ b/Tests/ConnectionTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import PusherChatkit
+
+class ConnectionTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        let deleteResourcesEx = expectation(description: "delete resources")
+        let createRolesEx = expectation(description: "create roles")
+
+        deleteInstanceResources() { err in
+            XCTAssertNil(err)
+            deleteResourcesEx.fulfill()
+        }
+
+        wait(for: [deleteResourcesEx], timeout: 15)
+
+        createStandardInstanceRoles() { err in
+            XCTAssertNil(err)
+            createRolesEx.fulfill()
+        }
+
+        wait(for: [createRolesEx], timeout: 15)
+    }
+
+    func testConnectionWorksWithWeirdUserIDs() {
+        let usersCreatedEx = expectation(description: "users created")
+
+        let weirdUserIDs = [
+            "user id with spaces",
+            "ⓤⓢⓔⓡ①",
+            "ЦƧΣЯ1",
+            "u҉s҉e҉r҉1҉",
+            // emoji
+            "🧘emojizen",
+            // Combining diacritics (é)
+            "e\u{0301}",
+            // Modified emoji (e.g. skin tones)
+            "🙆🏽",
+            "with/slash",
+            "addaboy++"
+        ]
+
+        var connectionExpectations = [XCTestExpectation]()
+
+        let userIDsToExpectations = weirdUserIDs.reduce(into: [String: XCTestExpectation]()) { res, id in
+            let exp = expectation(description: "\(id) connected successfully")
+            connectionExpectations.append(exp)
+            res[id] = exp
+        }
+        let usersToCreate = weirdUserIDs.map { ["id": $0, "name": $0] }
+
+        createUsers(users: usersToCreate) { err in
+            XCTAssertNil(err)
+            usersCreatedEx.fulfill()
+        }
+
+        wait(for: [usersCreatedEx], timeout: 20)
+
+        var chatManagers = [ChatManager]()
+
+        weirdUserIDs.forEach { id in
+            let chatManager = newTestChatManager(userID: id)
+            chatManagers.append(chatManager)
+            chatManager.connect(delegate: TestingChatManagerDelegate()) { cUser, err in
+                XCTAssertNil(err)
+                XCTAssertEqual(cUser!.id, id)
+                userIDsToExpectations[id]!.fulfill()
+            }
+        }
+
+        wait(for: connectionExpectations, timeout: 30)
+    }
+}


### PR DESCRIPTION
### What?

Make sure we use an encoded user ID for the test token provider's query parameter

### Why?

Make user IDs with non-alphanumeric characters work.

---

**NOTE**

We need to release a new version of pusher-platform-swift and update the dev here before merging to make sure everything works.

----

CC @hamchapman