### PR TITLE
Stop enforcing that PCRoomDelegates conform to NSObjectProtocol

### DIFF
--- a/Sources/PCRoomDelegate.swift
+++ b/Sources/PCRoomDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PusherPlatform
 
-public protocol PCRoomDelegate: NSObjectProtocol {
+public protocol PCRoomDelegate: AnyObject {
     func onMessage(_ message: PCMessage)
 
     @available(*, deprecated, renamed: "onNewReadCursor")


### PR DESCRIPTION
### What?

It's unnecessary

### Why?

Fixes #126 

----

CC @hamchapman
