### PR TITLE
Sync dictionary concurrency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.3.0...HEAD)
+## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.3.1...HEAD)
+
+## [1.3.1](https://github.com/pusher/chatkit-swift/compare/1.3.0...1.3.1) - 2019-03-05
+
+### Fixed
+
+- `PCSynchronizedDictionary` uses a serial queue. Previously setting values would happen
+  ansynchronously without any barriers which could give us a wrong result. For sake of
+  simplicity, the queue has been made serial with sync operations.
 
 ## [1.3.0](https://github.com/pusher/chatkit-swift/compare/1.2.3...1.3.0) - 2019-01-25
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "pusher/pusher-platform-swift" ~> 0.6
+github "pusher/pusher-platform-swift" ~> 0.7.1
 github "pusher/beams-chatkit-swift" ~> 1.2
 
 # you'll need something like this if working locally and you want

--- a/PusherChatkit.podspec
+++ b/PusherChatkit.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'Sources/*.swift'
 
-  s.dependency 'PusherPlatform', '~> 0.6'
+  s.dependency 'PusherPlatform', '~> 0.7.1'
   s.ios.dependency 'BeamsChatkit', '~> 1.2'
   s.macos.dependency 'BeamsChatkit', '~> 1.2'
 

--- a/PusherChatkit.podspec
+++ b/PusherChatkit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherChatkit'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'Pusher Chatkit SDK in Swift'
   s.homepage         = 'https://github.com/pusher/chatkit-swift'
   s.license          = 'MIT'

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -48,7 +48,7 @@ import NotificationCenter
 
         self.logger = logger
 
-        let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "1.3.0")
+        let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "1.3.1")
         let sharedBaseClient = baseClient ?? PCBaseClient(host: "\(cluster).pusherplatform.io", sdkInfo: sdkInfo)
         sharedBaseClient.logger = logger
 

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -39,10 +39,6 @@ public final class PCCurrentUser {
     public internal(set) var presenceSubscription: PCPresenceSubscription?
     public internal(set) var cursorSubscription: PCCursorSubscription?
 
-    private let roomSubscriptionQueue = DispatchQueue(
-        label: "com.pusher.chatkit.room-subscriptions"
-    )
-
     public var createdAtDate: Date { return PCDateFormatter.shared.formatString(self.createdAt) }
     public var updatedAtDate: Date { return PCDateFormatter.shared.formatString(self.updatedAt) }
 

--- a/Sources/PCSynchronizedDictionary.swift
+++ b/Sources/PCSynchronizedDictionary.swift
@@ -78,7 +78,7 @@ public final class PCSynchronizedDictionary<KeyType: Hashable, ValueType>: Expre
     }
 
     func removeAll() {
-        queue.async {
+        queue.sync {
             self.underlyingDictionary.removeAll()
         }
     }

--- a/Tests/ChatManagerTests.swift
+++ b/Tests/ChatManagerTests.swift
@@ -18,7 +18,7 @@ class ChatManagerTests: XCTestCase {
         )
 
         let sdkProductName = "chatkit"
-        let sdkVersion = "1.3.0"
+        let sdkVersion = "1.3.1"
         let sdkLanguage = "swift"
 
         let baseClientHeaders = chatManager.instance.client.generalRequestURLSession.configuration.httpAdditionalHeaders as! [String: String]

--- a/Tests/Supporting Files/Info.plist
+++ b/Tests/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### What?

- Use a serial queue with synchronous tasks for the `PCSynchronizedDictionary`.
- Remove an unused queue in `PCCurrentUser`

### Why?

Reduce complexity and ensure that we have correct data. I verified by running the code below as a test

```swift
func testSyncDict() {
        do {
            let dict = PCSynchronizedDictionary<Int, Int>()
            var iterations = 1000

            DispatchQueue.concurrentPerform(iterations: iterations) { index in
                dict[index] = index+1
                print("SET value \(index) to \(index+1)")

                let idx = dict[index]
                if idx == nil {
                    print("NO value for \(index)")
                } else {
                    print("GET value \(idx!) for \(index)")
                }

                DispatchQueue.global().sync {
                    iterations -= 1

                    guard iterations <= 0 else { return }
                    print("DONE")
                    print(dict)
                }
            }
        }
    }
```

The existing version had several cases where keys were not found because setting values using `async` without barriers lead to races since someone could read the wrong value without waiting for the data to be mutated. 

----