### PR TITLE
PCPartUrlRequest initializer not accessible due to internal access specifier.

### DIFF
--- a/Sources/PCMultipartMessageRequest.swift
+++ b/Sources/PCMultipartMessageRequest.swift
@@ -30,6 +30,11 @@ public struct PCPartUrlRequest {
     let type: String
     let url: String
 
+    public init(type: String, url: String) {
+        self.type = type
+        self.url = url
+    }
+
     func toMap() -> [String: Any] {
         return [
             "type": self.type,


### PR DESCRIPTION
### What?
`PCPartURLRequest` cannot be initialized due to internal protection level. As if no initializer provided, it's default initializer access is set to `internal`.  Need to provide a constructor implementation which is public.

Ref : [Swift Doc](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html)
Check the Section : **Default Memberwise Initializers for Structure Types**

### Why?
`PCPartURLRequest` object is needed to initialized to be used by `PCPartRequest`. 
While copying the code from the [Pusher Example](https://docs.pusher.com/chatkit/reference/swift#sending-a-message), could not instantiate `PCPartURLRequest`


----