### PR TITLE
Use public access modifier where needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.4.1...HEAD)
+## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.4.2...HEAD)
+
+## [1.4.2](https://github.com/pusher/chatkit-swift/compare/1.4.1...1.4.2) - 2019-03-20
+
+## Fixed
+
+- Publicly exposed Multipart structs were previously using the `internal` access modifier
+  by default. This has now been changed to `public`.
 
 ## [1.4.1](https://github.com/pusher/chatkit-swift/compare/1.4.0...1.4.1) - 2019-03-12
 

--- a/PusherChatkit.podspec
+++ b/PusherChatkit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherChatkit'
-  s.version          = '1.4.1'
+  s.version          = '1.4.2'
   s.summary          = 'Pusher Chatkit SDK in Swift'
   s.homepage         = 'https://github.com/pusher/chatkit-swift'
   s.license          = 'MIT'

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -50,7 +50,7 @@ import NotificationCenter
 
         self.logger = logger
 
-        let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "1.4.1")
+        let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "1.4.2")
         let sharedBaseClient = baseClient ?? PCBaseClient(host: "\(cluster).pusherplatform.io", sdkInfo: sdkInfo)
         sharedBaseClient.logger = logger
 

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/PCMultipartMessage.swift
+++ b/Sources/PCMultipartMessage.swift
@@ -46,21 +46,21 @@ extension PCMultipartMessage: Hashable {
 }
 
 public struct PCPart {
-    let payload: PCMultipartPayload
+    public let payload: PCMultipartPayload
 
-    init(_ payload: PCMultipartPayload) {
+    public init(_ payload: PCMultipartPayload) {
         self.payload = payload
     }
 }
 
 public struct PCMultipartInlinePayload {
-    let type: String
-    let content: String
+    public let type: String
+    public let content: String
 }
 
 public struct PCMultipartURLPayload {
-    let type: String
-    let url: String
+    public let type: String
+    public let url: String
 }
 
 public enum PCMultipartPayload {
@@ -85,11 +85,11 @@ extension PCMultipartPayload: Equatable {
 }
 
 public class PCMultipartAttachmentPayload {
-    let type: String
-    let id: String
-    let name: String?
-    let customData: [String: Any]?
-    let size: Int
+    public let type: String
+    public let id: String
+    public let name: String?
+    public let customData: [String: Any]?
+    public let size: Int
     private let urlRefresher: PCMultipartAttachmentUrlRefresher
     internal let refreshUrl: String
     internal var downloadUrl: String

--- a/Sources/PCMultipartMessageRequest.swift
+++ b/Sources/PCMultipartMessageRequest.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct PCPartRequest {
     let payload: PCPartRequestType
 
-    init(_ payload: PCPartRequestType) {
+    public init(_ payload: PCPartRequestType) {
         self.payload = payload
     }
 }
@@ -13,7 +13,7 @@ public struct PCPartInlineRequest {
     let type: String
     let content: String
 
-    init(type: String = "text/plain", content: String) {
+    public init(type: String = "text/plain", content: String) {
         self.type = type
         self.content = content
     }
@@ -49,7 +49,7 @@ public struct PCPartAttachmentRequest {
     let name: String?
     let customData: [String: Any]?
 
-    init(
+    public init(
         type: String,
         file: Data,
         name: String? = nil,

--- a/Tests/ChatManagerTests.swift
+++ b/Tests/ChatManagerTests.swift
@@ -18,7 +18,7 @@ class ChatManagerTests: XCTestCase {
         )
 
         let sdkProductName = "chatkit"
-        let sdkVersion = "1.4.1"
+        let sdkVersion = "1.4.2"
         let sdkLanguage = "swift"
 
         let baseClientHeadersV2 = chatManager.v2Instance.client.generalRequestURLSession.configuration.httpAdditionalHeaders as! [String: String]

--- a/Tests/Supporting Files/Info.plist
+++ b/Tests/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### What?

Use `public` access modifier for structs and classes that are externally facing.

### Why?

Not specifying one defaults to internal and leads to unintended results.

----