### PR TITLE
Use absolute path desintation when construting request to refresh url

### DIFF
--- a/Sources/PCMultipartMessage.swift
+++ b/Sources/PCMultipartMessage.swift
@@ -155,7 +155,7 @@ public class PCMultipartAttachmentUrlRefresher {
         attachment: PCMultipartAttachmentPayload,
         completionHandler: @escaping (PCMultipartAttachmentPayload?, Error?) -> Void
     ) {
-        let request = PPRequestOptions(method: HTTPMethod.GET.rawValue, path: attachment.refreshUrl)
+        let request = PPRequestOptions(method: HTTPMethod.GET.rawValue, destination: .absolute(attachment.refreshUrl))
         self.client.request(
             using: request,
             onSuccess: { data in


### PR DESCRIPTION
### What?

Fix refresh URL construction.

### Why?

Previously it was using a relative path which meant that the result path constructed was wrong.

Fixes https://github.com/pusher/chatkit-swift/issues/167
----