### PR TITLE
Public initializers for payloads in multipart message 

### DIFF
--- a/Sources/PCMultipartMessage.swift
+++ b/Sources/PCMultipartMessage.swift
@@ -56,11 +56,21 @@ public struct PCPart {
 public struct PCMultipartInlinePayload {
     public let type: String
     public let content: String
+    
+    public init(type: String, content: String) {
+        self.type = type
+        self.content = content
+    }
 }
 
 public struct PCMultipartURLPayload {
     public let type: String
     public let url: String
+    
+    public init(type: String, url: String) {
+        self.type = type
+        self.url = url
+    }
 }
 
 public enum PCMultipartPayload {


### PR DESCRIPTION

### What?
In order to create messages locally outside the library we need to have public initializers. Otherwise they cannot be initialized due to internal accessibilty of those initializers

### Why?
The ability to setup and send messages internally without having to wait until the message is pushed through the server means we can have a "message in transit". If these initializers are internal, the entire messaging system needs to replicate the message structure. With these public initializers we create custom internal messages.

----
