### PR TITLE
Make PCSynchronizedArray operations serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.5.1...HEAD)
+## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.5.2...HEAD)
+
+## [1.5.2](https://github.com/pusher/chatkit-swift/compare/1.5.1...1.5.2) - 2019-06-11
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.5.1...HEAD)
 
+## Fixed
+
+- Potential memory corruptions in PCSynchronizedArrays
+
 ## [1.5.1](https://github.com/pusher/chatkit-swift/compare/1.5.0...1.5.1) - 2019-05-28
 
 ## Fixed

--- a/PusherChatkit.podspec
+++ b/PusherChatkit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherChatkit'
-  s.version          = '1.5.1'
+  s.version          = '1.5.2'
   s.summary          = 'Pusher Chatkit SDK in Swift'
   s.homepage         = 'https://github.com/pusher/chatkit-swift'
   s.license          = 'MIT'

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -50,7 +50,7 @@ import NotificationCenter
 
         self.logger = logger
 
-        let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "1.5.1")
+        let sdkInfo = PPSDKInfo(productName: "chatkit", sdkVersion: "1.5.2")
         let sharedBaseClient = baseClient ?? PCBaseClient(host: "\(cluster).pusherplatform.io", sdkInfo: sdkInfo)
         sharedBaseClient.logger = logger
 

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/PCSynchronizedArray.swift
+++ b/Sources/PCSynchronizedArray.swift
@@ -2,12 +2,12 @@ import Foundation
 
 public final class PCSynchronizedArray<T> {
     internal var underlyingArray: [T] = []
-    private let accessQueue = DispatchQueue(label: "synchronized.array.access.\(UUID().uuidString)", attributes: .concurrent)
+    private let accessQueue = DispatchQueue(label: "synchronized.array.access.\(UUID().uuidString)")
 
     public init() {}
 
     public func append(_ newElement: T, completionHandler: (() -> Void)? = nil) {
-        self.accessQueue.async(flags: .barrier) {
+        self.accessQueue.async {
             self.underlyingArray.append(newElement)
             completionHandler?()
         }
@@ -22,14 +22,14 @@ public final class PCSynchronizedArray<T> {
     }
 
     func appendAndComplete(_ newElement: T, completionHandler: @escaping (T) -> Void) {
-        self.accessQueue.async(flags: .barrier) {
+        self.accessQueue.async {
             self.underlyingArray.append(newElement)
             completionHandler(newElement)
         }
     }
 
     public func remove(where predicate: @escaping (T) -> Bool, completionHandler: ((T?) -> Void)? = nil) {
-        self.accessQueue.async(flags: .barrier) {
+        self.accessQueue.async {
             guard let index = self.underlyingArray.index(where: predicate) else {
                 completionHandler?(nil)
                 return
@@ -51,7 +51,7 @@ public final class PCSynchronizedArray<T> {
     }
 
     public func remove(at index: Int, completionHandler: ((T) -> Void)? = nil) {
-        self.accessQueue.async(flags: .barrier) {
+        self.accessQueue.async {
             let element = self.underlyingArray.remove(at: index)
             completionHandler?(element)
         }
@@ -96,7 +96,7 @@ public final class PCSynchronizedArray<T> {
     }
 
     public func remove(where predicate: @escaping (T) -> Bool, completion: ((T) -> Void)? = nil) {
-        self.accessQueue.async(flags: .barrier) {
+        self.accessQueue.async {
             guard let index = self.underlyingArray.index(where: predicate) else { return }
             let element = self.underlyingArray.remove(at: index)
             completion?(element)
@@ -127,7 +127,7 @@ public final class PCSynchronizedArray<T> {
 
     public subscript(index: Int) -> T {
         set {
-            self.accessQueue.async(flags: .barrier) {
+            self.accessQueue.async {
                 self.underlyingArray[index] = newValue
             }
         }
@@ -148,7 +148,7 @@ extension PCSynchronizedArray where T: PCUpdatable {
         predicate: @escaping (T) -> Bool,
         completionHandler: @escaping (T) -> Void
     ) {
-        self.accessQueue.async(flags: .barrier) {
+        self.accessQueue.async {
             if let existingValue = self.underlyingArray.first(where: predicate) {
                 existingValue.updateWithPropertiesOf(value)
                 completionHandler(existingValue)

--- a/Tests/ChatManagerTests.swift
+++ b/Tests/ChatManagerTests.swift
@@ -15,7 +15,7 @@ class ChatManagerTests: XCTestCase {
         )
 
         let sdkProductName = "chatkit"
-        let sdkVersion = "1.5.1"
+        let sdkVersion = "1.5.2"
         let sdkLanguage = "swift"
 
         let baseClientHeadersV2 = chatManager.v2Instance.client.generalRequestURLSession.configuration.httpAdditionalHeaders as! [String: String]

--- a/Tests/Supporting Files/Info.plist
+++ b/Tests/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### What?

Make PCSynchronizedArray operations serial.

### Why?

All async operations were already serialised using
the barrier flag, but synchronous mutations were
being allowed to run concurrently, potentially
corrupting the underlying array.

----
