### PR TITLE
Simplify concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-swift/compare/1.5.2...HEAD)
 
+### Fixed
+
+- Remove unnecessary async operations (internal ones)
+
 ## [1.5.2](https://github.com/pusher/chatkit-swift/compare/1.5.1...1.5.2) - 2019-06-11
 
 ## Fixed

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -1055,7 +1055,7 @@ public final class PCCurrentUser {
                                 return
                             }
                             
-                            messages.appendSync(message)
+                            messages.append(message)
                             if progressCounter.incrementSuccessAndCheckIfFinished() {
                                 completionHandler(
                                     messages.underlyingArray.sorted(

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -27,7 +27,7 @@ public final class PCCurrentUser {
     }
 
     public var rooms: [PCRoom] {
-        return self.roomStore.rooms.underlyingArray
+        return self.roomStore.rooms.clone()
     }
 
     public let pathFriendlyID: String
@@ -1044,21 +1044,21 @@ public final class PCCurrentUser {
                     )
         
                     basicMessages.forEach { basicMessage in
-                        messageEnricher.enrich(basicMessage) {	 message, err in
+                        messageEnricher.enrich(basicMessage) { message, err in
                             guard let message = message, err == nil else {
                                 instance.logger.log(err!.localizedDescription, logLevel: .debug)
                                 
                                 if progressCounter.incrementFailedAndCheckIfFinished() {
-                                    completionHandler(messages.underlyingArray.sorted(by: { $0.id > $1.id }), nil)
+                                    completionHandler(messages.clone().sorted(by: { $0.id > $1.id }), nil)
                                 }
-                                
+
                                 return
                             }
                             
                             messages.append(message)
                             if progressCounter.incrementSuccessAndCheckIfFinished() {
                                 completionHandler(
-                                    messages.underlyingArray.sorted(
+                                    messages.clone().sorted(
                                         by: { $0.id < $1.id }
                                     ),
                                     nil

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -154,10 +154,9 @@ public final class PCCurrentUser {
 
                 do {
                     let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
-                    self.roomStore.addOrMerge(room) { room in
-                        self.populateRoomUserStore(room) { room in
-                            completionHandler(room, nil)
-                        }
+                    self.roomStore.addOrMerge(room)
+                    self.populateRoomUserStore(room) { room in
+                        completionHandler(room, nil)
                     }
                 } catch let err {
                     completionHandler(nil, err)
@@ -405,10 +404,9 @@ public final class PCCurrentUser {
 
                 do {
                     let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
-                    self.roomStore.addOrMerge(room) { room in
-                        self.populateRoomUserStore(room) { room in
-                            completionHandler(room, nil)
-                        }
+                    self.roomStore.addOrMerge(room)
+                    self.populateRoomUserStore(room) { room in
+                        completionHandler(room, nil)
                     }
                 } catch let err {
                     self.v4Instance.logger.log(err.localizedDescription, logLevel: .debug)
@@ -1046,7 +1044,7 @@ public final class PCCurrentUser {
                     )
         
                     basicMessages.forEach { basicMessage in
-                        messageEnricher.enrich(basicMessage) { message, err in
+                        messageEnricher.enrich(basicMessage) {	 message, err in
                             guard let message = message, err == nil else {
                                 instance.logger.log(err!.localizedDescription, logLevel: .debug)
                                 
@@ -1057,15 +1055,14 @@ public final class PCCurrentUser {
                                 return
                             }
                             
-                            messages.append(message) {
-                                if progressCounter.incrementSuccessAndCheckIfFinished() {
-                                    completionHandler(
-                                        messages.underlyingArray.sorted(
-                                            by: { $0.id < $1.id }
-                                        ),
-                                        nil
-                                    )
-                                }
+                            messages.appendSync(message)
+                            if progressCounter.incrementSuccessAndCheckIfFinished() {
+                                completionHandler(
+                                    messages.underlyingArray.sorted(
+                                        by: { $0.id < $1.id }
+                                    ),
+                                    nil
+                                )
                             }
                         }
                     }

--- a/Sources/PCMultipartAttachmentUploader.swift
+++ b/Sources/PCMultipartAttachmentUploader.swift
@@ -61,9 +61,9 @@ class PCMultipartAttachmentUploader {
 
         self.dispatchGroup.notify(queue: .main) {
             if self.uploadFailures.count > 0 {
-                completionHandler(nil, self.uploadFailures.underlyingArray)
+                completionHandler(nil, self.uploadFailures.clone())
             } else {
-                completionHandler(self.uploadSuccesses.underlyingArray, nil)
+                completionHandler(self.uploadSuccesses.clone(), nil)
             }
         }
     }

--- a/Sources/PCMultipartAttachmentUploader.swift
+++ b/Sources/PCMultipartAttachmentUploader.swift
@@ -37,7 +37,7 @@ class PCMultipartAttachmentUploader {
                 self.uploadMultipartAttachment(task: task) { (attachmentID, error) in
                     defer { self.dispatchGroup.leave() }
                     guard error == nil else {
-                        self.uploadFailures.append(error!)
+                        self.uploadFailures.appendSync(error!)
                         self.instance.logger.log(
                             "Failed to upload multipart attachment: \(error.debugDescription)",
                             logLevel: .error
@@ -45,7 +45,7 @@ class PCMultipartAttachmentUploader {
                         return
                     }
 
-                    self.uploadSuccesses.append(
+                    self.uploadSuccesses.appendSync(
                         PCMultipartAttachmentUploadResult(
                             attachmentID: attachmentID!,
                             partNumber: task.partNumber,

--- a/Sources/PCMultipartAttachmentUploader.swift
+++ b/Sources/PCMultipartAttachmentUploader.swift
@@ -37,7 +37,7 @@ class PCMultipartAttachmentUploader {
                 self.uploadMultipartAttachment(task: task) { (attachmentID, error) in
                     defer { self.dispatchGroup.leave() }
                     guard error == nil else {
-                        self.uploadFailures.appendSync(error!)
+                        self.uploadFailures.append(error!)
                         self.instance.logger.log(
                             "Failed to upload multipart attachment: \(error.debugDescription)",
                             logLevel: .error
@@ -45,7 +45,7 @@ class PCMultipartAttachmentUploader {
                         return
                     }
 
-                    self.uploadSuccesses.appendSync(
+                    self.uploadSuccesses.append(
                         PCMultipartAttachmentUploadResult(
                             attachmentID: attachmentID!,
                             partNumber: task.partNumber,

--- a/Sources/PCRoomStore.swift
+++ b/Sources/PCRoomStore.swift
@@ -16,7 +16,7 @@ public final class PCRoomStore {
     }
 
     func addOrMerge(_ room: PCRoom) -> PCRoom {
-        return self.rooms.appendOrUpdateSync(
+        return self.rooms.appendOrUpdate(
             room,
             predicate: { $0.id == room.id }
         )
@@ -24,11 +24,11 @@ public final class PCRoomStore {
 
     @discardableResult
     func addOrMergeSync(_ room: PCRoom) -> PCRoom {
-        return self.rooms.appendOrUpdateSync(room, predicate: { $0.id == room.id })
+        return self.rooms.appendOrUpdate(room, predicate: { $0.id == room.id })
     }
 
     func removeSync(id: String) -> PCRoom? {
-        return self.rooms.removeSync(where: { $0.id == id })
+        return self.rooms.remove(where: { $0.id == id })
     }
 
     func findOrGetRoom(id: String, completionHandler: @escaping (PCRoom?, Error?) -> Void) {

--- a/Sources/PCRoomStore.swift
+++ b/Sources/PCRoomStore.swift
@@ -15,21 +15,16 @@ public final class PCRoomStore {
         self.findOrGetRoom(id: id, completionHandler: completionHandler)
     }
 
-    func addOrMerge(_ room: PCRoom, completionHandler: @escaping (PCRoom) -> Void) {
-        self.rooms.appendOrUpdate(
+    func addOrMerge(_ room: PCRoom) -> PCRoom {
+        return self.rooms.appendOrUpdateSync(
             room,
-            predicate: { $0.id == room.id },
-            completionHandler: completionHandler
+            predicate: { $0.id == room.id }
         )
     }
 
     @discardableResult
     func addOrMergeSync(_ room: PCRoom) -> PCRoom {
         return self.rooms.appendOrUpdateSync(room, predicate: { $0.id == room.id })
-    }
-
-    func remove(id: String, completionHandler: ((PCRoom?) -> Void)? = nil) {
-        return self.rooms.remove(where: { $0.id == id }, completionHandler: completionHandler)
     }
 
     func removeSync(id: String) -> PCRoom? {

--- a/Sources/PCSynchronizedArray.swift
+++ b/Sources/PCSynchronizedArray.swift
@@ -7,11 +7,9 @@ public final class PCSynchronizedArray<T> {
     public init() {}
 
     func clone() -> [T] {
-        var clone: [T] = []
-        self.accessQueue.sync {
-            clone = underlyingArray
+        return self.accessQueue.sync {
+            return underlyingArray
         }
-        return clone
     }
 
     func append(_ newElement: T) -> T {
@@ -33,41 +31,33 @@ public final class PCSynchronizedArray<T> {
     }
 
     public var count: Int {
-        var count = 0
-
-        self.accessQueue.sync {
-            count = self.underlyingArray.count
+        return self.accessQueue.sync {
+            return self.underlyingArray.count
         }
-
-        return count
     }
 
     public var isEmpty: Bool {
-        var result = false
-        self.accessQueue.sync { result = self.underlyingArray.isEmpty }
-        return result
+        return self.accessQueue.sync {
+            return self.underlyingArray.isEmpty
+        }
     }
 
     public func first(where predicate: (T) -> Bool) -> T? {
-        var element: T?
-
-        self.accessQueue.sync {
-            element = self.underlyingArray.first(where: predicate)
+        return self.accessQueue.sync {
+            return self.underlyingArray.first(where: predicate)
         }
-
-        return element
     }
 
     public var first: T? {
-        var result: T?
-        self.accessQueue.sync { result = self.underlyingArray.first }
-        return result
+        return self.accessQueue.sync {
+            return self.underlyingArray.first
+        }
     }
 
     public var last: T? {
-        var result: T?
-        self.accessQueue.sync { result = self.underlyingArray.last }
-        return result
+        return self.accessQueue.sync {
+            return self.underlyingArray.last
+        }
     }
 
     public func remove(where predicate: @escaping (T) -> Bool, completion: ((T) -> Void)? = nil) {
@@ -79,25 +69,27 @@ public final class PCSynchronizedArray<T> {
     }
 
     public func filter(_ isIncluded: @escaping (T) -> Bool) -> [T] {
-        var result = [T]()
-        self.accessQueue.sync { result = self.underlyingArray.filter(isIncluded) }
-        return result
+        return self.accessQueue.sync {
+            return self.underlyingArray.filter(isIncluded)
+        }
     }
 
     public func sorted(by areInIncreasingOrder: (T, T) -> Bool) -> [T] {
-        var result = [T]()
-        self.accessQueue.sync { result = self.underlyingArray.sorted(by: areInIncreasingOrder) }
-        return result
+        return self.accessQueue.sync {
+            return self.underlyingArray.sorted(by: areInIncreasingOrder)
+        }
     }
 
     public func compactMap<ElementOfResult>(_ transform: @escaping (T) -> ElementOfResult?) -> [ElementOfResult] {
-        var result = [ElementOfResult]()
-        self.accessQueue.sync { result = self.underlyingArray.compactMap(transform) }
-        return result
+        return self.accessQueue.sync {
+            return self.underlyingArray.compactMap(transform)
+        }
     }
 
     public func forEach(_ body: (T) -> Void) {
-        self.accessQueue.sync { self.underlyingArray.forEach(body) }
+        self.accessQueue.sync {
+            self.underlyingArray.forEach(body)
+        }
     }
 
     public subscript(index: Int) -> T {
@@ -107,12 +99,9 @@ public final class PCSynchronizedArray<T> {
             }
         }
         get {
-            var element: T!
-            self.accessQueue.sync {
-                element = self.underlyingArray[index]
+            return self.accessQueue.sync {
+                return self.underlyingArray[index]
             }
-
-            return element
         }
     }
 }

--- a/Sources/PCSynchronizedArray.swift
+++ b/Sources/PCSynchronizedArray.swift
@@ -60,14 +60,6 @@ public final class PCSynchronizedArray<T> {
         }
     }
 
-    public func remove(where predicate: @escaping (T) -> Bool, completion: ((T) -> Void)? = nil) {
-        self.accessQueue.async {
-            guard let index = self.underlyingArray.index(where: predicate) else { return }
-            let element = self.underlyingArray.remove(at: index)
-            completion?(element)
-        }
-    }
-
     public func filter(_ isIncluded: @escaping (T) -> Bool) -> [T] {
         return self.accessQueue.sync {
             return self.underlyingArray.filter(isIncluded)

--- a/Sources/PCSynchronizedArray.swift
+++ b/Sources/PCSynchronizedArray.swift
@@ -6,7 +6,7 @@ public final class PCSynchronizedArray<T> {
 
     public init() {}
 
-    func appendSync(_ newElement: T) -> T {
+    func append(_ newElement: T) -> T {
         self.accessQueue.sync {
             self.underlyingArray.append(newElement)
         }
@@ -14,7 +14,7 @@ public final class PCSynchronizedArray<T> {
         return newElement
     }
 
-    public func removeSync(where predicate: @escaping (T) -> Bool) -> T? {
+    public func remove(where predicate: @escaping (T) -> Bool) -> T? {
         return self.accessQueue.sync {
             guard let index = self.underlyingArray.index(where: predicate) else {
                 return nil
@@ -110,7 +110,7 @@ public final class PCSynchronizedArray<T> {
 }
 
 extension PCSynchronizedArray where T: PCUpdatable {
-    func appendOrUpdateSync(_ value: T, predicate: @escaping (T) -> Bool) -> T {
+    func appendOrUpdate(_ value: T, predicate: @escaping (T) -> Bool) -> T {
         return self.accessQueue.sync {
             if let existingValue = self.underlyingArray.first(where: predicate) {
                 existingValue.updateWithPropertiesOf(value)

--- a/Sources/PCSynchronizedArray.swift
+++ b/Sources/PCSynchronizedArray.swift
@@ -1,10 +1,18 @@
 import Foundation
 
 public final class PCSynchronizedArray<T> {
-    internal var underlyingArray: [T] = []
+    private var underlyingArray: [T] = []
     private let accessQueue = DispatchQueue(label: "synchronized.array.access.\(UUID().uuidString)")
 
     public init() {}
+
+    func clone() -> [T] {
+        var clone: [T] = []
+        self.accessQueue.sync {
+            clone = underlyingArray
+        }
+        return clone
+    }
 
     func append(_ newElement: T) -> T {
         self.accessQueue.sync {

--- a/Sources/PCSynchronizedDictionary.swift
+++ b/Sources/PCSynchronizedDictionary.swift
@@ -7,7 +7,7 @@ public final class PCSynchronizedDictionary<KeyType: Hashable, ValueType>: Expre
     typealias Index = Dictionary<KeyType, ValueType>.Index
     typealias Element = Dictionary<KeyType, ValueType>.Element
 
-    var underlyingDictionary: [KeyType: ValueType]
+    private var underlyingDictionary: [KeyType: ValueType]
     private let queue = DispatchQueue(
         label: "synchronized.dictionary.access.\(UUID().uuidString)"
     )

--- a/Tests/RoomMembershipTests.swift
+++ b/Tests/RoomMembershipTests.swift
@@ -52,6 +52,30 @@ class RoomMembershipTests: XCTestCase {
 
     // MARK: Chat manager delegate tests
 
+    func testMembersAreAvailableImmediatelyAfterCreation() {
+        let roomCreatedEx = expectation(description: "room was created")
+
+        self.aliceChatManager.connect(delegate: TestingChatManagerDelegate()) { alice, err in
+            XCTAssertNil(err)
+            alice!.createRoom(
+                name: "mushroom",
+                addUserIDs: ["bob"]
+            ) { room, err in
+                XCTAssertNil(err)
+                XCTAssertNotNil(room)
+                XCTAssertEqual(room!.userIDs.sorted(), ["alice", "bob"], "Room user IDs were not populated")
+                XCTAssertEqual(room!.users.map {$0.id}.sorted(), ["alice", "bob"], "Room users were not populated")
+                room!.users.forEach { user in
+                    XCTAssertTrue(alice!.users.contains(user))
+                }
+
+                roomCreatedEx.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 15)
+    }
+
     func testChatManagerUserJoinedRoomHookWhenUserJoins() {
         let userJoinedRoomHookEx = expectation(description: "user joined room hook called")
         let bobJoinedRoomEx = expectation(description: "bob joined room")


### PR DESCRIPTION
### What?

Remove async methods from SynchronizedArray

### Why?

Over the course of multiple changes, the synchronized array has now arrived at
the only reliable implementation - a wrapper around a shared datastructure
with all access serialised via a *non-concurrent* queue.

There is no point submitting tasks to this queue asynchronously and passing in
a completion handler to be invoked when the operation is complete - all we
achieve doing this is a proliferation of callbacks and, more importantly, the
moving of the completion handler invocations in to the critical section. We
actually lose what ever concurrency there may be in the callers.