### PR TITLE
Don't allow newly de-serialised entities to propagate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Remove unnecessary async operations (internal ones)
+- Don't allow references to newly deserialised entities to escape once their
+  details have been merged in to the canonical copies of the entity.
 
 ## [1.5.2](https://github.com/pusher/chatkit-swift/compare/1.5.1...1.5.2) - 2019-06-11
 

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -153,8 +153,7 @@ public final class PCCurrentUser {
                 }
 
                 do {
-                    let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
-                    self.roomStore.addOrMerge(room)
+                    let room = self.roomStore.addOrMerge(try PCPayloadDeserializer.createRoomFromPayload(roomPayload))
                     self.populateRoomUserStore(room) { room in
                         completionHandler(room, nil)
                     }
@@ -403,8 +402,7 @@ public final class PCCurrentUser {
                 }
 
                 do {
-                    let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
-                    self.roomStore.addOrMerge(room)
+                    let room = self.roomStore.addOrMerge(try PCPayloadDeserializer.createRoomFromPayload(roomPayload))
                     self.populateRoomUserStore(room) { room in
                         completionHandler(room, nil)
                     }

--- a/Sources/PCUserSubscription.swift
+++ b/Sources/PCUserSubscription.swift
@@ -148,9 +148,15 @@ extension PCUserSubscription {
         }
 
         do {
-            let room = try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
+            guard let currentUser = self.currentUser else {
+                print("currentUser is nil when parsing added to room event")
+                return
+            }
 
-            self.currentUser?.roomStore.addOrMerge(room)
+            let room = currentUser.roomStore.addOrMerge(
+                try PCPayloadDeserializer.createRoomFromPayload(roomPayload)
+            )
+
             self.delegate?.onAddedToRoom(room)
             self.instance.logger.log("Added to room: \(room.name)", logLevel: .verbose)
 


### PR DESCRIPTION
They should be tested against the existing store and the existing entity used if there is one (after being updated with new fields).

This is because the entities hold important state (including the subscriptions, in the case of rooms), something which will be removed from them in future to save this kind of error from being possible.