### PR TITLE
Guard mutable properties of PCUser

### DIFF
--- a/PusherChatkit.xcodeproj/project.pbxproj
+++ b/PusherChatkit.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		90FC150B22201A8E00EF464C /* PCMultipartMessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90FC150A22201A8E00EF464C /* PCMultipartMessageRequest.swift */; };
 		90FC150D2224421F00EF464C /* PCMultipartAttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90FC150C2224421F00EF464C /* PCMultipartAttachmentUploader.swift */; };
 		A14B8C3C2191AD1D0039AD5D /* ChatkitBeamsTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14B8C3B2191AD1D0039AD5D /* ChatkitBeamsTokenProvider.swift */; };
+		ED38C27822E0AA4300BF8DC2 /* DispatchSemaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38C27722E0AA4300BF8DC2 /* DispatchSemaphore.swift */; };
 		F2665DEE20FDEE56002A0A3D /* PresenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2665DED20FDEE56002A0A3D /* PresenceTests.swift */; };
 		F2665E0F20FE025D002A0A3D /* MessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2665E0E20FE025C002A0A3D /* MessageTests.swift */; };
 		F2AA717520F7616000BC01DE /* CursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2AA717420F7616000BC01DE /* CursorTests.swift */; };
@@ -170,6 +171,7 @@
 		90FC150C2224421F00EF464C /* PCMultipartAttachmentUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMultipartAttachmentUploader.swift; sourceTree = "<group>"; };
 		A14B8C3B2191AD1D0039AD5D /* ChatkitBeamsTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatkitBeamsTokenProvider.swift; sourceTree = "<group>"; };
 		A14F52F82189C1F200D4C284 /* PushNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PushNotifications.framework; path = Carthage/Build/iOS/PushNotifications.framework; sourceTree = "<group>"; };
+		ED38C27722E0AA4300BF8DC2 /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
 		F2665DED20FDEE56002A0A3D /* PresenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresenceTests.swift; sourceTree = "<group>"; };
 		F2665E0E20FE025C002A0A3D /* MessageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageTests.swift; sourceTree = "<group>"; };
 		F2AA717420F7616000BC01DE /* CursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CursorTests.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				90CF0390221AD1A300FAE8B2 /* PCBasicMultipartMessage.swift */,
 				90FC150A22201A8E00EF464C /* PCMultipartMessageRequest.swift */,
 				90FC150C2224421F00EF464C /* PCMultipartAttachmentUploader.swift */,
+				ED38C27722E0AA4300BF8DC2 /* DispatchSemaphore.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 33831C491A9CEDF800B124F1;
@@ -535,6 +539,7 @@
 				3704959A21876E3200DFC497 /* PCPresenceStateChange.swift in Sources */,
 				A14B8C3C2191AD1D0039AD5D /* ChatkitBeamsTokenProvider.swift in Sources */,
 				3397D4C21EC2017000DD5994 /* PCSynchronizedArray.swift in Sources */,
+				ED38C27822E0AA4300BF8DC2 /* DispatchSemaphore.swift in Sources */,
 				33B3DD9F1EF7E2F60050CA02 /* PCTokenProvider.swift in Sources */,
 				33E3EBC7200E2368003D888D /* PPTypealiases.swift in Sources */,
 				33C5D8F92020842200E826FB /* PCCursorSubscription.swift in Sources */,

--- a/Sources/DispatchSemaphore.swift
+++ b/Sources/DispatchSemaphore.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension DispatchSemaphore {
+    func synchronized<T>(_ operation: () -> T) -> T {
+        self.wait()
+        let v = operation()
+        self.signal()
+        return v
+    }
+}

--- a/Sources/PCRoom.swift
+++ b/Sources/PCRoom.swift
@@ -3,15 +3,16 @@ import PusherPlatform
 
 public final class PCRoom {
     public let id: String
-    public internal(set) var name: String
-    public private(set) var isPrivate: Bool
     public let createdByUserID: String
     public let createdAt: String
-    public internal(set) var updatedAt: String
-    public internal(set) var deletedAt: String?
-    public internal(set) var customData: [String: Any]?
-    public internal(set) var unreadCount: Int?
-    public internal(set) var lastMessageAt: String?
+
+    public private(set) var name: String
+    public private(set) var isPrivate: Bool
+    public private(set) var updatedAt: String
+    public private(set) var deletedAt: String?
+    public private(set) var customData: [String: Any]?
+    public private(set) var unreadCount: Int?
+    public private(set) var lastMessageAt: String?
 
     public internal(set) var subscription: PCRoomSubscription?
     public internal(set) var userIDs: Set<String>
@@ -28,7 +29,7 @@ public final class PCRoom {
         return Array(self.userStore.users).sorted(by: { $0.id > $1.id })
     }
 
-    public internal(set) var userStore: PCRoomUserStore
+    public private(set) var userStore: PCRoomUserStore
 
     public var createdAtDate: Date { return PCDateFormatter.shared.formatString(self.createdAt) }
     public var updatedAtDate: Date { return PCDateFormatter.shared.formatString(self.updatedAt) }

--- a/Sources/PCUser.swift
+++ b/Sources/PCUser.swift
@@ -1,26 +1,50 @@
 import Foundation
 
 public final class PCUser {
+    private let lock = DispatchSemaphore(value: 1)
+
+    // Immutable properties are safe
     public let id: String
     public let createdAt: String
-    public var updatedAt: String
-    public var name: String?
-    public var avatarURL: String?
-    public var customData: [String: Any]?
-    public internal(set) var presenceState: PCPresenceState
 
-    public lazy var pathFriendlyID: String = {
-        return pathFriendlyVersion(of: self.id)
-    }()
+    // Mutable properties must be protected, these should only be referenced in the constructor and guarded setters
+    private var _updatedAt: String
+    private var _name: String?
+    private var _avatarURL: String?
+    private var _customData: [String: Any]?
+    private var _presenceState: PCPresenceState
 
+    // Guarded setters for mutable properties
+    public var updatedAt: String {
+        get { return self.lock.synchronized { self._updatedAt } }
+        set(v) { self.lock.synchronized { self._updatedAt = v } }
+    }
+
+    public var name: String? {
+        get { return self.lock.synchronized { self._name } }
+        set(v) { self.lock.synchronized { self._name = v } }
+    }
+
+    public var avatarURL: String? {
+        get { return self.lock.synchronized { self._avatarURL } }
+        set(v) { self.lock.synchronized { self._avatarURL = v } }
+    }
+
+    public var customData: [String: Any]? {
+        get { return self.lock.synchronized { self._customData } }
+        set(v) { self.lock.synchronized { self._customData = v } }
+    }
+
+    public var presenceState: PCPresenceState {
+        get { return self.lock.synchronized { self._presenceState } }
+        set(v) { self.lock.synchronized { self._presenceState = v } }
+    }
+
+    // True computed properties
+    public var pathFriendlyID: String { return pathFriendlyVersion(of: self.id) }
     public var createdAtDate: Date { return PCDateFormatter.shared.formatString(self.createdAt) }
     public var updatedAtDate: Date { return PCDateFormatter.shared.formatString(self.updatedAt) }
-
-    public var displayName: String {
-        get {
-            return self.name ?? self.id
-        }
-    }
+    public var displayName: String { return self.name ?? self.id }
 
     public init(
         id: String,
@@ -32,11 +56,11 @@ public final class PCUser {
     ) {
         self.id = id
         self.createdAt = createdAt
-        self.updatedAt = updatedAt
-        self.name = name
-        self.avatarURL = avatarURL
-        self.customData = customData
-        self.presenceState = .unknown
+        self._updatedAt = updatedAt
+        self._name = name
+        self._avatarURL = avatarURL
+        self._customData = customData
+        self._presenceState = .unknown
     }
 
     func updatePresenceInfoIfAppropriate(newInfoPayload: PCPresencePayload) {

--- a/Sources/PCUser.swift
+++ b/Sources/PCUser.swift
@@ -14,7 +14,7 @@ public final class PCUser {
     private var _customData: [String: Any]?
     private var _presenceState: PCPresenceState
 
-    // Guarded setters for mutable properties
+    // Guarded getters and setters for mutable properties
     public var updatedAt: String {
         get { return self.lock.synchronized { self._updatedAt } }
         set(v) { self.lock.synchronized { self._updatedAt = v } }


### PR DESCRIPTION
### What?

Guard mutable properties of PCRoom and PCUser against concurrent reads/writes from different threads

### Why?

Crashes and corruption await those who make concurrent access to values from different threads. We desire neither.

----
