### PR TITLE
Fix for race conditions discovered with thread sanitizer

### DIFF
--- a/PusherChatkit.xcodeproj/xcshareddata/xcschemes/PusherChatkit.xcscheme
+++ b/PusherChatkit.xcodeproj/xcshareddata/xcschemes/PusherChatkit.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -17,13 +17,19 @@ import NotificationCenter
     public let cursorsInstance: Instance
     public let presenceInstance: Instance
 
+    private let lock = DispatchSemaphore(value: 1)
+    
     public let userID: String
     public let pathFriendlyUserID: String
 
     let connectionCoordinator: PCConnectionCoordinator
     var currentUser: PCCurrentUser?
 
-    var basicCurrentUser: PCBasicCurrentUser?
+    private var _basicCurrentUser: PCBasicCurrentUser?
+    var basicCurrentUser: PCBasicCurrentUser? {
+        get { return self.lock.synchronized { self._basicCurrentUser } }
+        set(v) { self.lock.synchronized { self._basicCurrentUser = v } }
+    }
 
     var wasPreviouslyConnected: Bool = false
 

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -23,7 +23,12 @@ import NotificationCenter
     public let pathFriendlyUserID: String
 
     let connectionCoordinator: PCConnectionCoordinator
-    var currentUser: PCCurrentUser?
+    
+    private var _currentUser: PCCurrentUser?
+    var currentUser: PCCurrentUser? {
+        get { return self.lock.synchronized { self._currentUser } }
+        set(v) { self.lock.synchronized { self._currentUser = v } }
+    }
 
     private var _basicCurrentUser: PCBasicCurrentUser?
     var basicCurrentUser: PCBasicCurrentUser? {

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -9,6 +9,8 @@ public final class PCCurrentUser {
     public var avatarURL: String?
     public var customData: [String: Any]?
 
+    private let lock = DispatchSemaphore(value: 1)
+    
     let userStore: PCGlobalUserStore
     let roomStore: PCRoomStore
     let cursorStore: PCCursorStore
@@ -33,7 +35,12 @@ public final class PCCurrentUser {
     public let pathFriendlyID: String
 
     public internal(set) var userSubscription: PCUserSubscription?
-    public internal(set) var presenceSubscription: PCPresenceSubscription?
+    
+    private var _presenceSubscription: PCPresenceSubscription?
+    public internal(set) var presenceSubscription: PCPresenceSubscription? {
+        get { return self.lock.synchronized { self._presenceSubscription } }
+        set(v) { self.lock.synchronized { self._presenceSubscription = v } }
+    }
 
     public var createdAtDate: Date { return PCDateFormatter.shared.formatString(self.createdAt) }
     public var updatedAtDate: Date { return PCDateFormatter.shared.formatString(self.updatedAt) }

--- a/Sources/PCReadCursorDebouncerManager.swift
+++ b/Sources/PCReadCursorDebouncerManager.swift
@@ -21,10 +21,17 @@ class PCReadCursorDebouncerManager {
 }
 
 class PCReadCursorDebouncer {
+    private let lock = DispatchSemaphore(value: 1)
+    
     private var roomID: String
     private weak var currentUser: PCCurrentUser?
     private var interval: TimeInterval
-    private var timer: PPRepeater?
+    
+    private var _timer: PPRepeater?
+    var timer: PPRepeater? {
+        get { return self.lock.synchronized { self._timer } }
+        set(v) { self.lock.synchronized { self._timer = v } }
+    }
 
     private var sendReadCursorPayload: (position: Int, completionHandlers: [PCErrorCompletionHandler])? = nil
 

--- a/Sources/PCTokenProvider.swift
+++ b/Sources/PCTokenProvider.swift
@@ -2,6 +2,8 @@ import Foundation
 import PusherPlatform
 
 public final class PCTokenProvider: PPTokenProvider {
+    private let lock = DispatchSemaphore(value: 1)
+    
     public let url: String
     public let requestInjector: ((PCTokenProviderRequest) -> PCTokenProviderRequest)?
     public var userID: String? = nil {
@@ -16,7 +18,12 @@ public final class PCTokenProvider: PPTokenProvider {
     var pathFriendUserID: String? = nil
 
     var fetchingToken: Bool = false
-    var queuedTokenRecipients: [(PPTokenProviderResult) -> Void] = []
+    
+    private var _queuedTokenRecipients: [(PPTokenProviderResult) -> Void] = []
+    var queuedTokenRecipients: [(PPTokenProviderResult) -> Void] {
+        get { return self.lock.synchronized { self._queuedTokenRecipients } }
+        set(v) { self.lock.synchronized { self._queuedTokenRecipients = v } }
+    }
 
     let queue = DispatchQueue(label: "com.pusher.chatkit.token-provider")
 


### PR DESCRIPTION
### What?

Guard mutable properties of `PCCurrentUser`, `PCReadCursorDebouncer`, `PCTokenProvider` and `ChatManager` against concurrent reads/writes from different threads.

### Why?

Improve stability of the SDK.

----