### PR TITLE
Remove redundant properties

### DIFF
--- a/Chatkit/Model/Room.swift
+++ b/Chatkit/Model/Room.swift
@@ -15,9 +15,6 @@ public struct Room {
     /// A boolean value that determines whether or not the room is private.
     public let isPrivate: Bool
     
-    /// The array of users currently typing on the room.
-    public let typingMembers: [User]
-    
     /// The number of unread messages for the given user in this room.
     ///
     /// The value of this property is only defined if the user is a member of the room.
@@ -44,11 +41,10 @@ public struct Room {
     
     // MARK: - Initializers
     
-    init(identifier: String, name: String?, isPrivate: Bool, typingMembers: [User], unreadCount: UInt64, lastMessage: Message?, userData: UserData?, createdAt: Date, updatedAt: Date, deletedAt: Date?, objectID: NSManagedObjectID) {
+    init(identifier: String, name: String?, isPrivate: Bool, unreadCount: UInt64, lastMessage: Message?, userData: UserData?, createdAt: Date, updatedAt: Date, deletedAt: Date?, objectID: NSManagedObjectID) {
         self.identifier = identifier
         self.name = name
         self.isPrivate = isPrivate
-        self.typingMembers = typingMembers
         self.unreadCount = unreadCount
         self.lastMessage = lastMessage
         self.userData = userData
@@ -91,7 +87,6 @@ extension Room: Equatable {
         return lhs.identifier == rhs.identifier
             && lhs.name == rhs.name
             && lhs.isPrivate == rhs.isPrivate
-            && lhs.typingMembers == rhs.typingMembers
             && lhs.unreadCount == rhs.unreadCount
             && lhs.lastMessage == rhs.lastMessage
             && lhs.createdAt == rhs.createdAt

--- a/Chatkit/Model/Room.swift
+++ b/Chatkit/Model/Room.swift
@@ -15,9 +15,6 @@ public struct Room {
     /// A boolean value that determines whether or not the room is private.
     public let isPrivate: Bool
     
-    /// The array of users on the room.
-    public let members: [User]
-    
     /// The array of users currently typing on the room.
     public let typingMembers: [User]
     
@@ -47,11 +44,10 @@ public struct Room {
     
     // MARK: - Initializers
     
-    init(identifier: String, name: String?, isPrivate: Bool, members: [User], typingMembers: [User], unreadCount: UInt64, lastMessage: Message?, userData: UserData?, createdAt: Date, updatedAt: Date, deletedAt: Date?, objectID: NSManagedObjectID) {
+    init(identifier: String, name: String?, isPrivate: Bool, typingMembers: [User], unreadCount: UInt64, lastMessage: Message?, userData: UserData?, createdAt: Date, updatedAt: Date, deletedAt: Date?, objectID: NSManagedObjectID) {
         self.identifier = identifier
         self.name = name
         self.isPrivate = isPrivate
-        self.members = members
         self.typingMembers = typingMembers
         self.unreadCount = unreadCount
         self.lastMessage = lastMessage
@@ -95,7 +91,6 @@ extension Room: Equatable {
         return lhs.identifier == rhs.identifier
             && lhs.name == rhs.name
             && lhs.isPrivate == rhs.isPrivate
-            && lhs.members == rhs.members
             && lhs.typingMembers == rhs.typingMembers
             && lhs.unreadCount == rhs.unreadCount
             && lhs.lastMessage == rhs.lastMessage

--- a/Chatkit/Persistence/Snapshotable/Entities/RoomEntity+Snapshotable.swift
+++ b/Chatkit/Persistence/Snapshotable/Entities/RoomEntity+Snapshotable.swift
@@ -29,14 +29,12 @@ extension RoomEntity: Snapshotable {
     
     func snapshot() throws -> Room {
         let lastMessage = (try? self.lastMessage?.snapshot()) ?? nil
-        let members = snapshot(self.members)
         let typingMembers = snapshot(self.typingMembers)
         let userData = UserDataSerializer.deserialize(data: self.userData)
         
         return Room(identifier: self.identifier,
                     name: self.name,
                     isPrivate: self.isPrivate,
-                    members: members,
                     typingMembers: typingMembers,
                     unreadCount: UInt64(self.unreadCount),
                     lastMessage: lastMessage,

--- a/Chatkit/Persistence/Snapshotable/Entities/RoomEntity+Snapshotable.swift
+++ b/Chatkit/Persistence/Snapshotable/Entities/RoomEntity+Snapshotable.swift
@@ -29,13 +29,11 @@ extension RoomEntity: Snapshotable {
     
     func snapshot() throws -> Room {
         let lastMessage = (try? self.lastMessage?.snapshot()) ?? nil
-        let typingMembers = snapshot(self.typingMembers)
         let userData = UserDataSerializer.deserialize(data: self.userData)
         
         return Room(identifier: self.identifier,
                     name: self.name,
                     isPrivate: self.isPrivate,
-                    typingMembers: typingMembers,
                     unreadCount: UInt64(self.unreadCount),
                     lastMessage: lastMessage,
                     userData: userData,

--- a/Chatkit/Test Data/RoomFactory.swift
+++ b/Chatkit/Test Data/RoomFactory.swift
@@ -16,7 +16,6 @@ class RoomFactory {
                 Room(identifier: "\($0)",
                     name: "Room \($0)",
                     isPrivate: false,
-                    members: [],
                     typingMembers: [],
                     unreadCount: 3,
                     lastMessage: nil,

--- a/Chatkit/Test Data/RoomFactory.swift
+++ b/Chatkit/Test Data/RoomFactory.swift
@@ -16,7 +16,6 @@ class RoomFactory {
                 Room(identifier: "\($0)",
                     name: "Room \($0)",
                     isPrivate: false,
-                    typingMembers: [],
                     unreadCount: 3,
                     lastMessage: nil,
                     userData: nil,


### PR DESCRIPTION
### What?

Remove `members` and `typingMembers` properties from `Room`.

### Why?

Provide room members and typing indicators from dedicated providers.

----
