### PR TITLE
Prevent crash due to a force unwrap when updating cursor

### DIFF
--- a/Sources/PCReadCursorDebouncerManager.swift
+++ b/Sources/PCReadCursorDebouncerManager.swift
@@ -50,9 +50,11 @@ class PCReadCursorDebouncer {
     }
 
     func set(position: Int, completionHandler: @escaping PCErrorCompletionHandler) {
-        if sendReadCursorPayload != nil {
-            sendReadCursorPayload!.position = max(position, sendReadCursorPayload!.position)
-            sendReadCursorPayload!.completionHandlers = sendReadCursorPayload!.completionHandlers + [completionHandler]
+        if let previousCursor = sendReadCursorPayload {
+            sendReadCursorPayload = (
+                position: max(position, previousCursor.position),
+                completionHandlers: previousCursor.completionHandlers + [completionHandler]
+            )
         } else {
             sendReadCursorPayload = (
                 position: position,


### PR DESCRIPTION
### What?
I was getting crashes when updating the cursor for a chat room. Code was using force unwrap after checking for nil
Here is the relevant stack trace:

```swift
* thread #1, queue = 'com.apple.main-thread', stop reason = Fatal error: Unexpectedly found nil while unwrapping an Optional value
    frame #0: 0x00000001eb28b194 libswiftCore.dylib`_swift_runtime_on_report
    frame #1: 0x00000001eb2e1738 libswiftCore.dylib`_swift_stdlib_reportFatalErrorInFile + 188
    frame #2: 0x00000001eb02ad20 libswiftCore.dylib`function signature specialization <Arg[1] = [Closure Propagated : closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in Swift._assertionFailure(_: Swift.StaticString, _: Swift.String, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never, Argument Types : [Swift.StaticStringSwift.UnsafeBufferPointer<Swift.UInt8>Swift.UIntSwift.UInt32]> of generic specialization <()> of Swift.String._withUnsafeBufferPointerToUTF8<A>((Swift.UnsafeBufferPointer<Swift.UInt8>) throws -> A) throws -> A + 408
    frame #3: 0x00000001eb206b98 libswiftCore.dylib`function signature specialization <Arg[0] = Exploded, Arg[1] = Exploded> of Swift._assertionFailure(_: Swift.StaticString, _: Swift.String, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never + 352
    frame #4: 0x00000001eb02a2bc libswiftCore.dylib`Swift._assertionFailure(_: Swift.StaticString, _: Swift.String, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never + 32
  * frame #5: 0x0000000106fb898c PusherChatkit`PCReadCursorDebouncer.set(position=100955425, completionHandler=0x0000000100a56e50 Sharezie Dev`closure #1 (Swift.Optional<Swift.Error>) -> () in Sharezie_Dev.SharezieChatManager.setReadCursor(roomId: Swift.String, messageId: Swift.Int) -> () at SharezieChatManager.swift:241, self=0x00000002812ad3b0) at PCReadCursorDebouncerManager.swift:55:55
    frame #6: 0x0000000106fb6d94 PusherChatkit`PCReadCursorDebouncerManager.set(position=100955425, roomID="19543693", completionHandler=0x0000000100a56e50 Sharezie Dev`closure #1 (Swift.Optional<Swift.Error>) -> () in Sharezie_Dev.SharezieChatManager.setReadCursor(roomId: Swift.String, messageId: Swift.Int) -> () at SharezieChatManager.swift:241, self=0x00000002836ca9a0) at PCReadCursorDebouncerManager.swift:14:23
    frame #7: 0x0000000106f7a118 PusherChatkit`PCCurrentUser.setReadCursor(position=100955425, roomID="19543693", completionHandler=0x0000000100a56e50 Sharezie Dev`closure #1 (Swift.Optional<Swift.Error>) -> () in Sharezie_Dev.SharezieChatManager.setReadCursor(roomId: Swift.String, messageId: Swift.Int) -> () at SharezieChatManager.swift:241, self=0x00000001099c4200) at PCCurrentUser.swift:1129:36
```
### Why?
Avoid crashing.
