### PR TITLE
Update the beams sdk which supports multiple instances and consume

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 github "pusher/pusher-platform-swift" ~> 0.7.2
-github "pusher/push-notifications-swift" ~> 2.1.2
+github "pusher/push-notifications-swift" ~> 3.0.1
 
 # you'll need something like this if working locally and you want
 # to test changes to pusher-platform-swift

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "hamchapman/Mockingjay" "6bbe3ad2139609e56c0bd5f2fa0e7911dc13a6f8"
 github "krzyzanowskim/CryptoSwift" "1.0.0"
-github "pusher/push-notifications-swift" "2.1.2"
+github "pusher/push-notifications-swift" "3.0.1"
 github "pusher/pusher-platform-swift" "0.7.2"

--- a/PusherChatkit.podspec
+++ b/PusherChatkit.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/*.swift'
 
   s.dependency 'PusherPlatform', '~> 0.7.2'
-  s.ios.dependency 'PushNotifications', '~> 2.1.2'
-  s.macos.dependency 'PushNotifications', '~> 2.1.2'
+  s.ios.dependency 'PushNotifications', '~> 3.0.1'
+  s.macos.dependency 'PushNotifications', '~> 3.0.1'
 
   s.ios.deployment_target = '10.0'
   s.macos.deployment_target = '10.12'

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -401,8 +401,6 @@ func pathFriendlyVersion(of component: String) -> String {
 
 #if os(iOS) || os(macOS)
 // MARK: Beams
-private let pushNotifications: PushNotifications = PushNotifications.shared
-
 extension ChatManager {
     /**
      Register device token with PushNotifications service.
@@ -410,7 +408,7 @@ extension ChatManager {
      - Parameter deviceToken: A token that identifies the device to APNs.
      */
     public static func registerDeviceToken(_ deviceToken: Data) {
-        pushNotifications.registerDeviceToken(deviceToken)
+        PushNotifications.shared.registerDeviceToken(deviceToken)
     }
     /**
      Register to receive remote notifications via Apple Push Notification service.
@@ -420,7 +418,7 @@ extension ChatManager {
      - SeeAlso:  `registerForRemoteNotifications(options:)`
      */
     public static func registerForRemoteNotifications() {
-        pushNotifications.registerForRemoteNotifications()
+        PushNotifications.shared.registerForRemoteNotifications()
     }
     #if os(iOS)
     /**
@@ -429,7 +427,7 @@ extension ChatManager {
      - Parameter options: The authorization options your app is requesting. You may combine the available constants to request authorization for multiple items. Request only the authorization options that you plan to use. For a list of possible values, see [UNAuthorizationOptions](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions).
      */
     public static func registerForRemoteNotifications(options: UNAuthorizationOptions) {
-        pushNotifications.registerForRemoteNotifications(options: options)
+        PushNotifications.shared.registerForRemoteNotifications(options: options)
     }
     #elseif os(macOS)
     /**
@@ -438,14 +436,14 @@ extension ChatManager {
      - Parameter options: A bit mask specifying the types of notifications the app accepts. See [NSApplication.RemoteNotificationType](https://developer.apple.com/documentation/appkit/nsapplication.remotenotificationtype) for valid bit-mask values.
      */
     public static func registerForRemoteNotifications(options: NSApplication.RemoteNotificationType) {
-        pushNotifications.registerForRemoteNotifications(options: options)
+        PushNotifications.shared.registerForRemoteNotifications(options: options)
     }
     #endif
     /**
      Disable push notifications service.
      */
     public static func disablePushNotifications() {
-        pushNotifications.clearAllState {
+        PushNotifications.shared.clearAllState {
             let logger = PCDefaultLogger()
             logger.log("Push Notifications Disabled 🚫", logLevel: .debug)
         }

--- a/Sources/ChatManager.swift
+++ b/Sources/ChatManager.swift
@@ -408,7 +408,7 @@ extension ChatManager {
      - Parameter deviceToken: A token that identifies the device to APNs.
      */
     public static func registerDeviceToken(_ deviceToken: Data) {
-        PushNotifications.shared.registerDeviceToken(deviceToken)
+        PushNotificationsStatic.registerDeviceToken(deviceToken)
     }
     /**
      Register to receive remote notifications via Apple Push Notification service.
@@ -418,7 +418,7 @@ extension ChatManager {
      - SeeAlso:  `registerForRemoteNotifications(options:)`
      */
     public static func registerForRemoteNotifications() {
-        PushNotifications.shared.registerForRemoteNotifications()
+        PushNotificationsStatic.registerForRemoteNotifications()
     }
     #if os(iOS)
     /**
@@ -427,7 +427,7 @@ extension ChatManager {
      - Parameter options: The authorization options your app is requesting. You may combine the available constants to request authorization for multiple items. Request only the authorization options that you plan to use. For a list of possible values, see [UNAuthorizationOptions](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions).
      */
     public static func registerForRemoteNotifications(options: UNAuthorizationOptions) {
-        PushNotifications.shared.registerForRemoteNotifications(options: options)
+        PushNotificationsStatic.registerForRemoteNotifications(options: options)
     }
     #elseif os(macOS)
     /**
@@ -436,14 +436,14 @@ extension ChatManager {
      - Parameter options: A bit mask specifying the types of notifications the app accepts. See [NSApplication.RemoteNotificationType](https://developer.apple.com/documentation/appkit/nsapplication.remotenotificationtype) for valid bit-mask values.
      */
     public static func registerForRemoteNotifications(options: NSApplication.RemoteNotificationType) {
-        PushNotifications.shared.registerForRemoteNotifications(options: options)
+        PPushNotificationsStatic.registerForRemoteNotifications(options: options)
     }
     #endif
     /**
      Disable push notifications service.
      */
     public static func disablePushNotifications() {
-        PushNotifications.shared.clearAllState {
+        PushNotificationsStatic.clearAllState {
             let logger = PCDefaultLogger()
             logger.log("Push Notifications Disabled 🚫", logLevel: .debug)
         }

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -1285,27 +1285,24 @@ public typealias PCRoomsCompletionHandler = ([PCRoom]?, Error?) -> Void
 #if os(iOS) || os(macOS)
 import PushNotifications
 
-private let pushNotifications: PushNotifications = PushNotifications.shared
-
 extension PCCurrentUser {
     /**
      Start PushNotifications service.
      */
     public func enablePushNotifications() {
-        pushNotifications.start(instanceId: self.v6Instance.id)
-        self.setUser(self.id)
-        ChatManager.registerForRemoteNotifications()
-    }
+        let beamsClient = PushNotifications.init(instanceId: self.v6Instance.id)
+        beamsClient.start()
 
-    private func setUser(_ userId: String) {
         let chatkitBeamsTokenProvider = ChatkitBeamsTokenProvider(instance: self.chatkitBeamsTokenProviderInstance)
-        pushNotifications.setUserId(userId, tokenProvider: chatkitBeamsTokenProvider) { error in
+        beamsClient.setUserId(self.id, tokenProvider: chatkitBeamsTokenProvider) { error in
              guard error == nil else {
                 return self.v6Instance.logger.log("Error occured while setting the user: \(error!)", logLevel: .error)
             }
 
             self.v6Instance.logger.log("Push Notifications service enabled 🎉", logLevel: .debug)
         }
+
+        ChatManager.registerForRemoteNotifications()
     }
 }
 #endif

--- a/Sources/PCCurrentUser.swift
+++ b/Sources/PCCurrentUser.swift
@@ -1290,7 +1290,7 @@ extension PCCurrentUser {
      Start PushNotifications service.
      */
     public func enablePushNotifications() {
-        let beamsClient = PushNotifications.init(instanceId: self.v6Instance.id)
+        let beamsClient = PushNotifications(instanceId: self.v6Instance.id)
         beamsClient.start()
 
         let chatkitBeamsTokenProvider = ChatkitBeamsTokenProvider(instance: self.chatkitBeamsTokenProviderInstance)


### PR DESCRIPTION
### What?
We updated the beams sdk and updated where we use it to support multiple instances.

To test this we added a chatkit instance id into the demo app + instantiated beams e.g. our app delegate looked like the following:

```swift
 let instanceLocator = "CHATKIT_INSTANCE_LOCATOR"

        let pusherChat = ChatManager(
            instanceLocator: instanceLocator,
            tokenProvider: PCTokenProvider(url: "CHATKIT_TOKEN_PROVIDER"),
            userID: "danielle",
            logger: TestLogger()
        )

        self.pusherChat = pusherChat

        // Initiate the registration process with Apple Push Notification service.
        
        ChatManager.registerForRemoteNotifications()
        
        self.beamsClient.start(instanceId: "BEAMS_INSTANCE_ID")
        self.beamsClient.registerForRemoteNotifications()
```


### Why?
This will enable people to use beams + chatkit in the same app


----
