### PR TITLE
OKP Cursor optional

### DIFF
--- a/Chatkit.xcodeproj/project.pbxproj
+++ b/Chatkit.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		73A9394523E1FB800025AF90 /* MakeInstanceLocatorFile */ = {
+		73A9394523E1FB800025AF90 /* Make InstanceLocator File */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 73A9394623E1FB800025AF90 /* Build configuration list for PBXAggregateTarget "MakeInstanceLocatorFile" */;
+			buildConfigurationList = 73A9394623E1FB800025AF90 /* Build configuration list for PBXAggregateTarget "Make InstanceLocator File" */;
 			buildPhases = (
 				73A9394923E1FB8B0025AF90 /* ShellScript */,
 			);
 			dependencies = (
 			);
-			name = MakeInstanceLocatorFile;
-			productName = MakeInstanceLocatorFile;
+			name = "Make InstanceLocator File";
+			productName = "Make InstanceLocator File";
 		};
 /* End PBXAggregateTarget section */
 
@@ -206,7 +206,7 @@
 			containerPortal = 229093CC22F1DDB4003DDE2C /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 73A9394523E1FB800025AF90;
-			remoteInfo = MakeInstanceLocatorFile;
+			remoteInfo = "Make InstanceLocator File";
 		};
 		73E585CB23E089420047C6FA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1319,7 +1319,7 @@
 				73E585BE23E087500047C6FA /* Test Utilities */,
 				224B803722F1E009003CB8DC /* Unit Tests */,
 				222910DA23D8A5D900A3ACDF /* System Tests */,
-				73A9394523E1FB800025AF90 /* MakeInstanceLocatorFile */,
+				73A9394523E1FB800025AF90 /* Make InstanceLocator File */,
 			);
 		};
 /* End PBXProject section */
@@ -1578,7 +1578,7 @@
 		};
 		73A9394B23E1FBCE0025AF90 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 73A9394523E1FB800025AF90 /* MakeInstanceLocatorFile */;
+			target = 73A9394523E1FB800025AF90 /* Make InstanceLocator File */;
 			targetProxy = 73A9394A23E1FBCE0025AF90 /* PBXContainerItemProxy */;
 		};
 		73E585CC23E089420047C6FA /* PBXTargetDependency */ = {
@@ -1922,7 +1922,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		73A9394623E1FB800025AF90 /* Build configuration list for PBXAggregateTarget "MakeInstanceLocatorFile" */ = {
+		73A9394623E1FB800025AF90 /* Build configuration list for PBXAggregateTarget "Make InstanceLocator File" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				73A9394723E1FB800025AF90 /* Debug */,

--- a/Chatkit/Networking/Model/Subscription/Wire.Event.Subscription.swift
+++ b/Chatkit/Networking/Model/Subscription/Wire.Event.Subscription.swift
@@ -5,7 +5,7 @@ extension Wire.Event {
     internal struct Subscription {
         
         let eventName: Name
-        let data: EventType
+        let data: Wire.Event.EventType
         let timestamp: Date
         
         enum Name: String {

--- a/Chatkit/Networking/Model/Wire.Cursor.swift
+++ b/Chatkit/Networking/Model/Wire.Cursor.swift
@@ -5,7 +5,7 @@ extension Wire {
     internal struct Cursor {
         let roomIdentifier: String
         let userIdentifier: String
-        let cursorType: CursorType
+        let cursorType: Wire.CursorType
         let position: Int64
         let updatedAt: Date
     }

--- a/Chatkit/Networking/Model/Wire.Message.swift
+++ b/Chatkit/Networking/Model/Wire.Message.swift
@@ -8,7 +8,7 @@ extension Wire {
         let identifier: Int64
         let userIdentifier: String
         let roomIdentifier: String
-        let parts: [MessagePart]
+        let parts: [Wire.MessagePart]
         let createdAt: Date
         let updatedAt: Date
     }

--- a/Chatkit/Networking/Model/Wire.ReadState.swift
+++ b/Chatkit/Networking/Model/Wire.ReadState.swift
@@ -5,7 +5,7 @@ extension Wire {
     internal struct ReadState {
         let roomIdentifier: String
         let unreadCount: UInt64
-        let cursor: Cursor
+        let cursor: Wire.Cursor?
     }
 
 }

--- a/Unit Tests/Tests/Networking/Model/Wire.ReadState+Decodable.Tests.swift
+++ b/Unit Tests/Tests/Networking/Model/Wire.ReadState+Decodable.Tests.swift
@@ -23,11 +23,11 @@ class WireReadStateDecodableTests: XCTestCase {
         XCTAssertNoThrow(try Wire.ReadState(from: jsonData.jsonDecoder())) { readState in
             XCTAssertEqual(readState.roomIdentifier, "ac43dfef")
             XCTAssertEqual(readState.unreadCount, 3)
-            XCTAssertEqual(readState.cursor.roomIdentifier, "ac43dfef")
-            XCTAssertEqual(readState.cursor.userIdentifier, "alice")
-            XCTAssertEqual(readState.cursor.cursorType, .read)
-            XCTAssertEqual(readState.cursor.position, 43398)
-            XCTAssertEqual(readState.cursor.updatedAt, Date(fromISO8601String: "2017-04-13T14:10:04Z"))
+            XCTAssertEqual(readState.cursor?.roomIdentifier, "ac43dfef")
+            XCTAssertEqual(readState.cursor?.userIdentifier, "alice")
+            XCTAssertEqual(readState.cursor?.cursorType, .read)
+            XCTAssertEqual(readState.cursor?.position, 43398)
+            XCTAssertEqual(readState.cursor?.updatedAt, Date(fromISO8601String: "2017-04-13T14:10:04Z"))
         }
     }
     
@@ -159,7 +159,7 @@ class WireReadStateDecodableTests: XCTestCase {
                                           "Expected to decode UInt64 but found a string/data instead."])
     }
     
-    func test_init_cursorMissing_throws() {
+    func test_init_cursorMissing_noProblem() {
         
         let jsonData = """
         {
@@ -168,12 +168,14 @@ class WireReadStateDecodableTests: XCTestCase {
         }
         """.toJsonData()
         
-        XCTAssertThrowsError(try Wire.ReadState(from: jsonData.jsonDecoder()),
-                             containing: ["keyNotFound",
-                                          "\"cursor\""])
+        XCTAssertNoThrow(try Wire.ReadState(from: jsonData.jsonDecoder())) { readState in
+            XCTAssertEqual(readState.roomIdentifier, "ac43dfef")
+            XCTAssertEqual(readState.unreadCount, 3)
+            XCTAssertEqual(readState.cursor, nil)
+        }
     }
     
-    func test_init_cursorNull_throws() {
+    func test_init_cursorNull_noProblem() {
         
         let jsonData = """
         {
@@ -183,10 +185,11 @@ class WireReadStateDecodableTests: XCTestCase {
         }
         """.toJsonData()
         
-        XCTAssertThrowsError(try Wire.ReadState(from: jsonData.jsonDecoder()),
-                             containing: ["valueNotFound",
-                                          "\"cursor\"",
-                                          "Cannot get keyed decoding container -- found null value instead."])
+        XCTAssertNoThrow(try Wire.ReadState(from: jsonData.jsonDecoder())) { readState in
+            XCTAssertEqual(readState.roomIdentifier, "ac43dfef")
+            XCTAssertEqual(readState.unreadCount, 3)
+            XCTAssertEqual(readState.cursor, nil)
+        }
     }
     
     func test_init_cursorInvalidType_throws() {


### PR DESCRIPTION
### What?

Made `cursor` value of a `read_state` *optional*.

### Why?

To fix bug when parsing code from production API

### Also ....
Renamed `Make InstanceLocator File` target adding spaces so that is consistent with a) the target of the same name in the PusherPlatform project and b) with the names of other targets in this project

----
