### PR TITLE
Expose JoinedRoomsRepository and JoinedRoomsViewModel as protocols

### DIFF
--- a/Chatkit.xcodeproj/project.pbxproj
+++ b/Chatkit.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		222773A024111B2F00FF2AA1 /* JoinedRoomsRepositoryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2227739F24111B2F00FF2AA1 /* JoinedRoomsRepositoryDelegate.swift */; };
 		222773A224111FE500FF2AA1 /* JoinedRoomsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222773A124111FE500FF2AA1 /* JoinedRoomsRepository.swift */; };
 		222773A42411218E00FF2AA1 /* JoinedRoomsViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222773A32411218E00FF2AA1 /* JoinedRoomsViewModelDelegate.swift */; };
-		222773A6241121F100FF2AA1 /* JoinedRoomsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222773A5241121F100FF2AA1 /* JoinedRoomsViewModelTests.swift */; };
+		222773A6241121F100FF2AA1 /* ConcreteJoinedRoomsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222773A5241121F100FF2AA1 /* ConcreteJoinedRoomsViewModelTests.swift */; };
 		222910EA23D8A6C300A3ACDF /* TestTokenProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222910E923D8A6C300A3ACDF /* TestTokenProviderTests.swift */; };
 		222C963F23F5489400321C94 /* UserListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222C963E23F5489400321C94 /* UserListState.swift */; };
 		222C964323F552FB00321C94 /* RoomUpdatedAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222C964223F552FB00321C94 /* RoomUpdatedAction.swift */; };
@@ -381,7 +381,7 @@
 		2227739F24111B2F00FF2AA1 /* JoinedRoomsRepositoryDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsRepositoryDelegate.swift; sourceTree = "<group>"; };
 		222773A124111FE500FF2AA1 /* JoinedRoomsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsRepository.swift; sourceTree = "<group>"; };
 		222773A32411218E00FF2AA1 /* JoinedRoomsViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsViewModelDelegate.swift; sourceTree = "<group>"; };
-		222773A5241121F100FF2AA1 /* JoinedRoomsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsViewModelTests.swift; sourceTree = "<group>"; };
+		222773A5241121F100FF2AA1 /* ConcreteJoinedRoomsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteJoinedRoomsViewModelTests.swift; sourceTree = "<group>"; };
 		222910DB23D8A5D900A3ACDF /* System Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "System Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		222910DF23D8A5D900A3ACDF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		222910E923D8A6C300A3ACDF /* TestTokenProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTokenProviderTests.swift; sourceTree = "<group>"; };
@@ -723,7 +723,7 @@
 			children = (
 				2227738C2410443100FF2AA1 /* Change Reasons */,
 				2227738D2410443600FF2AA1 /* States */,
-				222773A5241121F100FF2AA1 /* JoinedRoomsViewModelTests.swift */,
+				222773A5241121F100FF2AA1 /* ConcreteJoinedRoomsViewModelTests.swift */,
 			);
 			path = "View Models";
 			sourceTree = "<group>";
@@ -2285,7 +2285,7 @@
 				7335D27323D715E800E51909 /* CodableJSONCollections+DictionaryEncodingTests.swift in Sources */,
 				73EDEE5223D8ABCB00DE566D /* ConcreteInstanceWrapperFactoryTests.swift in Sources */,
 				22406A8323F4263E00EE24BE /* RemovedFromRoomReducerTests.swift in Sources */,
-				222773A6241121F100FF2AA1 /* JoinedRoomsViewModelTests.swift in Sources */,
+				222773A6241121F100FF2AA1 /* ConcreteJoinedRoomsViewModelTests.swift in Sources */,
 				7301BC7023B0FCCE00F162C7 /* Wire.Event.RoomUpdated+Decodable.Tests.swift in Sources */,
 				7301BC6D23B0FCCE00F162C7 /* Wire.Event.ReadStateUpdated+Decodable.Tests.swift in Sources */,
 				7301BC7123B0FCCE00F162C7 /* Wire.Event.AddedToRoom+Decodable.Tests.swift in Sources */,

--- a/Chatkit.xcodeproj/project.pbxproj
+++ b/Chatkit.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		2200BB93231E727000BF9545 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2200BB92231E727000BF9545 /* DateFormatter+Extensions.swift */; };
-		22090F0923FEECAC00E82C93 /* JoinedRoomsRepositoryFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22090F0823FEECAC00E82C93 /* JoinedRoomsRepositoryFilter.swift */; };
+		22090F0923FEECAC00E82C93 /* ConcreteJoinedRoomsRepositoryFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22090F0823FEECAC00E82C93 /* ConcreteJoinedRoomsRepositoryFilter.swift */; };
 		22090F0C23FEF2AF00E82C93 /* Transformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22090F0B23FEF2AF00E82C93 /* Transformer.swift */; };
 		220911D523ED6F97001A2D9A /* InitialStateReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220911D423ED6F97001A2D9A /* InitialStateReducerTests.swift */; };
 		220D99232406BA4600B0FD92 /* ListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220D99222406BA4600B0FD92 /* ListState.swift */; };
@@ -38,7 +38,7 @@
 		2227739124104E8100FF2AA1 /* JoinedRoomsViewModelStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2227739024104E8100FF2AA1 /* JoinedRoomsViewModelStateTests.swift */; };
 		222773942410F69000FF2AA1 /* ConcreteConnectivityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222773932410F69000FF2AA1 /* ConcreteConnectivityMonitorTests.swift */; };
 		222773962411020500FF2AA1 /* ConnectivityMonitorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222773952411020500FF2AA1 /* ConnectivityMonitorDelegate.swift */; };
-		22277398241107D900FF2AA1 /* JoinedRoomsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22277397241107D900FF2AA1 /* JoinedRoomsRepositoryTests.swift */; };
+		22277398241107D900FF2AA1 /* ConcreteJoinedRoomsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22277397241107D900FF2AA1 /* ConcreteJoinedRoomsRepositoryTests.swift */; };
 		2227739C2411083600FF2AA1 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2227739B2411083600FF2AA1 /* Buffer.swift */; };
 		2227739E2411084200FF2AA1 /* ConnectivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2227739D2411084200FF2AA1 /* ConnectivityMonitor.swift */; };
 		222773A024111B2F00FF2AA1 /* JoinedRoomsRepositoryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2227739F24111B2F00FF2AA1 /* JoinedRoomsRepositoryDelegate.swift */; };
@@ -100,7 +100,7 @@
 		2282205024096A8B004B99E7 /* JoinedRoomsViewModelChangeReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2282204F24096A8B004B99E7 /* JoinedRoomsViewModelChangeReason.swift */; };
 		2286409F240935880022370E /* ConnectivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2286409E240935880022370E /* ConnectivityMonitor.swift */; };
 		228C2D6A2400131600FC0326 /* ConcreteTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C2D692400131600FC0326 /* ConcreteTransformerTests.swift */; };
-		228C2D6E240016C300FC0326 /* JoinedRoomsFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C2D6D240016C300FC0326 /* JoinedRoomsFilterTests.swift */; };
+		228C2D6E240016C300FC0326 /* ConcreteJoinedRoomsRepositoryFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C2D6D240016C300FC0326 /* ConcreteJoinedRoomsRepositoryFilterTests.swift */; };
 		228C2D7124001FF200FC0326 /* ReadSummaryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C2D7024001FF200FC0326 /* ReadSummaryStateTests.swift */; };
 		228C2D732400268200FC0326 /* RoomStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C2D722400268200FC0326 /* RoomStateTests.swift */; };
 		228C2D752400279900FC0326 /* RoomListStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C2D742400279900FC0326 /* RoomListStateTests.swift */; };
@@ -359,7 +359,7 @@
 /* Begin PBXFileReference section */
 		2200BB92231E727000BF9545 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
 		2200BB96231EA5C200BF9545 /* TestLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
-		22090F0823FEECAC00E82C93 /* JoinedRoomsRepositoryFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsRepositoryFilter.swift; sourceTree = "<group>"; };
+		22090F0823FEECAC00E82C93 /* ConcreteJoinedRoomsRepositoryFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteJoinedRoomsRepositoryFilter.swift; sourceTree = "<group>"; };
 		22090F0B23FEF2AF00E82C93 /* Transformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transformer.swift; sourceTree = "<group>"; };
 		220911D423ED6F97001A2D9A /* InitialStateReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialStateReducerTests.swift; sourceTree = "<group>"; };
 		220D99222406BA4600B0FD92 /* ListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListState.swift; sourceTree = "<group>"; };
@@ -375,7 +375,7 @@
 		2227739024104E8100FF2AA1 /* JoinedRoomsViewModelStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsViewModelStateTests.swift; sourceTree = "<group>"; };
 		222773932410F69000FF2AA1 /* ConcreteConnectivityMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteConnectivityMonitorTests.swift; sourceTree = "<group>"; };
 		222773952411020500FF2AA1 /* ConnectivityMonitorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitorDelegate.swift; sourceTree = "<group>"; };
-		22277397241107D900FF2AA1 /* JoinedRoomsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsRepositoryTests.swift; sourceTree = "<group>"; };
+		22277397241107D900FF2AA1 /* ConcreteJoinedRoomsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteJoinedRoomsRepositoryTests.swift; sourceTree = "<group>"; };
 		2227739B2411083600FF2AA1 /* Buffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
 		2227739D2411084200FF2AA1 /* ConnectivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitor.swift; sourceTree = "<group>"; };
 		2227739F24111B2F00FF2AA1 /* JoinedRoomsRepositoryDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsRepositoryDelegate.swift; sourceTree = "<group>"; };
@@ -443,7 +443,7 @@
 		2282204F24096A8B004B99E7 /* JoinedRoomsViewModelChangeReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsViewModelChangeReason.swift; sourceTree = "<group>"; };
 		2286409E240935880022370E /* ConnectivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitor.swift; sourceTree = "<group>"; };
 		228C2D692400131600FC0326 /* ConcreteTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteTransformerTests.swift; sourceTree = "<group>"; };
-		228C2D6D240016C300FC0326 /* JoinedRoomsFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRoomsFilterTests.swift; sourceTree = "<group>"; };
+		228C2D6D240016C300FC0326 /* ConcreteJoinedRoomsRepositoryFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteJoinedRoomsRepositoryFilterTests.swift; sourceTree = "<group>"; };
 		228C2D7024001FF200FC0326 /* ReadSummaryStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadSummaryStateTests.swift; sourceTree = "<group>"; };
 		228C2D722400268200FC0326 /* RoomStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateTests.swift; sourceTree = "<group>"; };
 		228C2D742400279900FC0326 /* RoomListStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListStateTests.swift; sourceTree = "<group>"; };
@@ -1139,7 +1139,7 @@
 			isa = PBXGroup;
 			children = (
 				227C7C1C23FD82A9001DE4E5 /* StateFilter.swift */,
-				22090F0823FEECAC00E82C93 /* JoinedRoomsRepositoryFilter.swift */,
+				22090F0823FEECAC00E82C93 /* ConcreteJoinedRoomsRepositoryFilter.swift */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -1198,7 +1198,7 @@
 			children = (
 				228C2D6C240016BA00FC0326 /* Filters */,
 				22AFE0E4240EB77900056A43 /* States */,
-				22277397241107D900FF2AA1 /* JoinedRoomsRepositoryTests.swift */,
+				22277397241107D900FF2AA1 /* ConcreteJoinedRoomsRepositoryTests.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -1206,7 +1206,7 @@
 		228C2D6C240016BA00FC0326 /* Filters */ = {
 			isa = PBXGroup;
 			children = (
-				228C2D6D240016C300FC0326 /* JoinedRoomsFilterTests.swift */,
+				228C2D6D240016C300FC0326 /* ConcreteJoinedRoomsRepositoryFilterTests.swift */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -2268,7 +2268,7 @@
 				222C964D23F55EC400321C94 /* AddedToRoomReducerTests.swift in Sources */,
 				73A9392323E192FC0025AF90 /* String+ExtensionTests.swift in Sources */,
 				73CF01BC23AB823F006FB43E /* Wire.ReadState+Decodable.Tests.swift in Sources */,
-				22277398241107D900FF2AA1 /* JoinedRoomsRepositoryTests.swift in Sources */,
+				22277398241107D900FF2AA1 /* ConcreteJoinedRoomsRepositoryTests.swift in Sources */,
 				7335D27523D7330900E51909 /* CodableJSONCollections+ArrayEncodingTests.swift in Sources */,
 				228C2D7D240034A600FC0326 /* VersionedStateTests.swift in Sources */,
 				73233B2A23CF69A7001909B7 /* ConcreteSubscriptionActionDispatcherTests.swift in Sources */,
@@ -2308,7 +2308,7 @@
 				7335D26F23D705F300E51909 /* CodableJSONCollections+DictionaryDecodingTests.swift in Sources */,
 				734D6A4423AAA7D300105479 /* Wire.CursorType+Decodable.Tests.swift in Sources */,
 				734D6A4023AAA3CE00105479 /* Wire.Cursor+Decodable.Tests.swift in Sources */,
-				228C2D6E240016C300FC0326 /* JoinedRoomsFilterTests.swift in Sources */,
+				228C2D6E240016C300FC0326 /* ConcreteJoinedRoomsRepositoryFilterTests.swift in Sources */,
 				7301BC6E23B0FCCE00F162C7 /* Wire.Event.InitialState+Decodable.Tests.swift in Sources */,
 				22AFE0D6240E6EA500056A43 /* SubscriptionStateUpdatedReducerTests.swift in Sources */,
 				7301BC7523B1149D00F162C7 /* Wire.Event.IsTyping+Decodable.Tests.swift in Sources */,
@@ -2372,7 +2372,7 @@
 				2282205024096A8B004B99E7 /* JoinedRoomsViewModelChangeReason.swift in Sources */,
 				22D2A2EA23197E7F0095757C /* ConnectionStatus.swift in Sources */,
 				22090F0C23FEF2AF00E82C93 /* Transformer.swift in Sources */,
-				22090F0923FEECAC00E82C93 /* JoinedRoomsRepositoryFilter.swift in Sources */,
+				22090F0923FEECAC00E82C93 /* ConcreteJoinedRoomsRepositoryFilter.swift in Sources */,
 				222C964B23F55BA500321C94 /* AddedToRoomReducer.swift in Sources */,
 				734D6A3E23AAA2C900105479 /* Wire.Cursor.swift in Sources */,
 				73233AC323CE1A0D001909B7 /* SubscriptionFactory.swift in Sources */,

--- a/Chatkit/Chatkit/Chatkit.swift
+++ b/Chatkit/Chatkit/Chatkit.swift
@@ -133,11 +133,11 @@ public class Chatkit {
     ///
     /// This will provide access to a real time set of `Room`s that the current user is a member of.
     public func makeJoinedRoomsRepository() -> JoinedRoomsRepository {
-        let filter = JoinedRoomsRepository.Filter()
+        let filter = ConcreteJoinedRoomsRepository.Filter()
         let buffer = ConcreteBuffer(filter: filter, dependencies: self.dependencies)
         let connectivityMonitor = ConcreteConnectivityMonitor(subscriptionType: .user, dependencies: self.dependencies)
         
-        return JoinedRoomsRepository(buffer: buffer, connectivityMonitor: connectivityMonitor, dependencies: self.dependencies)
+        return ConcreteJoinedRoomsRepository(buffer: buffer, connectivityMonitor: connectivityMonitor, dependencies: self.dependencies)
     }
     
     /// Creates an instance of `MessagesRepository`.

--- a/Chatkit/Chatkit/Chatkit.swift
+++ b/Chatkit/Chatkit/Chatkit.swift
@@ -184,7 +184,7 @@ public class Chatkit {
     public func makeJoinedRoomsViewModel() -> JoinedRoomsViewModel {
         let repository = self.makeJoinedRoomsRepository()
         
-        return JoinedRoomsViewModel(repository: repository)
+        return ConcreteJoinedRoomsViewModel(repository: repository)
     }
     
     /// Creates an instance of `MessagesViewModel`.

--- a/Chatkit/Repositories/Change Reasons/JoinedRoomsRepositoryChangeReason.swift
+++ b/Chatkit/Repositories/Change Reasons/JoinedRoomsRepositoryChangeReason.swift
@@ -1,45 +1,41 @@
 
-public extension JoinedRoomsRepository {
+/// Enumeration that describes changes introduced to the state of `JoinedRoomsRepository`.
+public enum JoinedRoomsRepositoryChangeReason {
     
-    /// Enumeration that describes changes introduced to the state of `JoinedRoomsRepository`.
-    enum ChangeReason {
-        
-        /// Notifies the receiver that the current user has been added to a room.
-        ///
-        /// - Parameters:
-        ///     - room: The room joined by the user.
-        case addedToRoom(room: Room)
-        
-        /// Notifies the receiver that the current user has been removed from a room.
-        ///
-        /// - Parameters:
-        ///     - room: The room which the user is no longer a member of.
-        case removedFromRoom(room: Room)
-        
-        /// Notifies the receiver that a room the current user is a member of has been updated.
-        ///
-        /// - Parameters:
-        ///     - updatedRoom: The new value of the room.
-        ///     - previousValue: The value of the room befrore it was updated.
-        case roomUpdated(updatedRoom: Room, previousValue: Room)
-        
-        /// Notifies the receiver that a read state summary of a room the current user is a member of has been updated.
-        ///
-        /// - Parameters:
-        ///     - updatedRoom: The new value of the room.
-        ///     - previousValue: The value of the room befrore it was updated.
-        case readStateUpdated(updatedRoom: Room, previousValue: Room)
-        
-        /// Notifies the receiver that a room has been deleted.
-        ///
-        /// - Parameters:
-        ///     - room: The room which the user is no longer a member of.
-        case roomDeleted(room: Room)
-        
-    }
+    /// Notifies the receiver that the current user has been added to a room.
+    ///
+    /// - Parameters:
+    ///     - room: The room joined by the user.
+    case addedToRoom(room: Room)
+    
+    /// Notifies the receiver that the current user has been removed from a room.
+    ///
+    /// - Parameters:
+    ///     - room: The room which the user is no longer a member of.
+    case removedFromRoom(room: Room)
+    
+    /// Notifies the receiver that a room the current user is a member of has been updated.
+    ///
+    /// - Parameters:
+    ///     - updatedRoom: The new value of the room.
+    ///     - previousValue: The value of the room befrore it was updated.
+    case roomUpdated(updatedRoom: Room, previousValue: Room)
+    
+    /// Notifies the receiver that a read state summary of a room the current user is a member of has been updated.
+    ///
+    /// - Parameters:
+    ///     - updatedRoom: The new value of the room.
+    ///     - previousValue: The value of the room befrore it was updated.
+    case readStateUpdated(updatedRoom: Room, previousValue: Room)
+    
+    /// Notifies the receiver that a room has been deleted.
+    ///
+    /// - Parameters:
+    ///     - room: The room which the user is no longer a member of.
+    case roomDeleted(room: Room)
     
 }
 
 // MARK: - Equatable
 
-extension JoinedRoomsRepository.ChangeReason: Equatable {}
+extension JoinedRoomsRepositoryChangeReason: Equatable {}

--- a/Chatkit/Repositories/Filters/ConcreteJoinedRoomsRepositoryFilter.swift
+++ b/Chatkit/Repositories/Filters/ConcreteJoinedRoomsRepositoryFilter.swift
@@ -1,5 +1,5 @@
 
-internal extension JoinedRoomsRepository {
+internal extension ConcreteJoinedRoomsRepository {
     
     struct Filter: StateFilter {
         

--- a/Chatkit/Repositories/JoinedRoomsRepository.swift
+++ b/Chatkit/Repositories/JoinedRoomsRepository.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - Protocol
+
 /// A repository which exposes a collection of all rooms joined by the user.
 ///
 /// Construct an instance of this class using `Chatkit.createJoinedRoomsRepository(...)`
@@ -22,7 +24,34 @@ import Foundation
 ///   - `.connected`: updates are flowing live, or
 ///   - `.degraded`: updates may be delayed due to network problems, or
 ///   - `.closed`: the connection is closed, no further updates available.
-public class JoinedRoomsRepository: JoinedRoomsRepositoryProtocol {
+public protocol JoinedRoomsRepository: AnyObject {
+    
+    /// The current state of the repository.
+    var state: JoinedRoomsRepositoryState { get }
+    
+    /// The object that is notified when the `state` has changed.
+    var delegate: JoinedRoomsRepositoryDelegate? { get set }
+    
+}
+
+// MARK: - Delegate
+
+/// A delegate protocol for being notified when the `state` property of a `JoinedRoomsRepository`
+/// has changed.
+public protocol JoinedRoomsRepositoryDelegate: AnyObject {
+    
+    /// Notifies the receiver that the `state` of the repository has changed.
+    ///
+    /// - Parameters:
+    ///     - joinedRoomsRepository: The `JoinedRoomsRepository` that called the method.
+    ///     - state: The updated value of the `state`.
+    func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepositoryState)
+    
+}
+
+// MARK: - Concrete implementation
+
+class ConcreteJoinedRoomsRepository: JoinedRoomsRepository {
     
     // MARK: - Types
     
@@ -54,7 +83,6 @@ public class JoinedRoomsRepository: JoinedRoomsRepositoryProtocol {
         }
     }
     
-    /// The object that is notified when the `state` has changed.
     public weak var delegate: JoinedRoomsRepositoryDelegate?
     
     // MARK: - Initializers
@@ -105,7 +133,7 @@ public class JoinedRoomsRepository: JoinedRoomsRepositoryProtocol {
 
 // MARK: - Buffer delegate
 
-extension JoinedRoomsRepository: BufferDelegate {
+extension ConcreteJoinedRoomsRepository: BufferDelegate {
     
     func buffer(_ buffer: Buffer, didUpdateState state: VersionedState) {
         self.state = Self.state(forConnectionState: self.connectionState,
@@ -119,7 +147,7 @@ extension JoinedRoomsRepository: BufferDelegate {
 
 // MARK: - Connectivity monitor delegate
 
-extension JoinedRoomsRepository: ConnectivityMonitorDelegate {
+extension ConcreteJoinedRoomsRepository: ConnectivityMonitorDelegate {
     
     func connectivityMonitor(_ connectivityMonitor: ConnectivityMonitor, didUpdateConnectionState connectionState: ConnectionState) {
         self.state = Self.state(forConnectionState: connectionState,
@@ -128,29 +156,5 @@ extension JoinedRoomsRepository: ConnectivityMonitorDelegate {
                                                  usingTransformer: self.dependencies.transformer)
         self.connectionState = connectionState
     }
-    
-}
-
-// MARK: - Delegate
-
-/// A delegate protocol for being notified when the `state` property of a `JoinedRoomsRepository`
-/// has changed.
-public protocol JoinedRoomsRepositoryDelegate: AnyObject {
-    
-    /// Notifies the receiver that the `state` of the repository has changed.
-    ///
-    /// - Parameters:
-    ///     - joinedRoomsRepository: The `JoinedRoomsRepository` that called the method.
-    ///     - state: The updated value of the `state`.
-    func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepositoryState)
-    
-}
-
-// MARK: - Protocol
-
-protocol JoinedRoomsRepositoryProtocol: AnyObject {
-    
-    var state: JoinedRoomsRepositoryState { get }
-    var delegate: JoinedRoomsRepositoryDelegate? { get set }
     
 }

--- a/Chatkit/Repositories/JoinedRoomsRepository.swift
+++ b/Chatkit/Repositories/JoinedRoomsRepository.swift
@@ -37,7 +37,7 @@ public class JoinedRoomsRepository: JoinedRoomsRepositoryProtocol {
     private var versionedState: VersionedState?
     private var connectionState: ConnectionState
     
-    public private(set) var state: State {
+    public private(set) var state: JoinedRoomsRepositoryState {
         didSet {
             if state != oldValue {
                 if let delegate = self.delegate as? JoinedRoomsViewModel {
@@ -78,7 +78,7 @@ public class JoinedRoomsRepository: JoinedRoomsRepositoryProtocol {
     
     // MARK: - Private methods
     
-    private static func state(forConnectionState connectionState: ConnectionState, versionedState: VersionedState?, previousVersionedState: VersionedState?, usingTransformer transformer: Transformer) -> State {
+    private static func state(forConnectionState connectionState: ConnectionState, versionedState: VersionedState?, previousVersionedState: VersionedState?, usingTransformer transformer: Transformer) -> JoinedRoomsRepositoryState {
         if let versionedState = versionedState {
             let rooms = Set(versionedState.chatState.joinedRooms.map { transformer.transform(state: $0) })
             let changeReason = transformer.transform(currentState: versionedState, previousState: previousVersionedState)
@@ -142,7 +142,7 @@ public protocol JoinedRoomsRepositoryDelegate: AnyObject {
     /// - Parameters:
     ///     - joinedRoomsRepository: The `JoinedRoomsRepository` that called the method.
     ///     - state: The updated value of the `state`.
-    func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepository.State)
+    func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepositoryState)
     
 }
 
@@ -150,7 +150,7 @@ public protocol JoinedRoomsRepositoryDelegate: AnyObject {
 
 protocol JoinedRoomsRepositoryProtocol: AnyObject {
     
-    var state: JoinedRoomsRepository.State { get }
+    var state: JoinedRoomsRepositoryState { get }
     var delegate: JoinedRoomsRepositoryDelegate? { get set }
     
 }

--- a/Chatkit/Repositories/JoinedRoomsRepository.swift
+++ b/Chatkit/Repositories/JoinedRoomsRepository.swift
@@ -94,9 +94,9 @@ class ConcreteJoinedRoomsRepository: JoinedRoomsRepository {
         self.connectionState = connectivityMonitor.connectionState
         
         self.state = Self.state(forConnectionState: connectivityMonitor.connectionState,
-                                                 versionedState: buffer.currentState,
-                                                 previousVersionedState: nil,
-                                                 usingTransformer: dependencies.transformer)
+                                versionedState: buffer.currentState,
+                                previousVersionedState: nil,
+                                usingTransformer: dependencies.transformer)
         
         self.buffer.delegate = self
         self.connectivityMonitor.delegate = self
@@ -135,9 +135,9 @@ extension ConcreteJoinedRoomsRepository: BufferDelegate {
     
     func buffer(_ buffer: Buffer, didUpdateState state: VersionedState) {
         self.state = Self.state(forConnectionState: self.connectionState,
-                                                 versionedState: state,
-                                                 previousVersionedState: self.versionedState,
-                                                 usingTransformer: self.dependencies.transformer)
+                                versionedState: state,
+                                previousVersionedState: self.versionedState,
+                                usingTransformer: self.dependencies.transformer)
         self.versionedState = state
     }
     
@@ -149,9 +149,9 @@ extension ConcreteJoinedRoomsRepository: ConnectivityMonitorDelegate {
     
     func connectivityMonitor(_ connectivityMonitor: ConnectivityMonitor, didUpdateConnectionState connectionState: ConnectionState) {
         self.state = Self.state(forConnectionState: connectionState,
-                                                 versionedState: self.versionedState,
-                                                 previousVersionedState: self.versionedState,
-                                                 usingTransformer: self.dependencies.transformer)
+                                versionedState: self.versionedState,
+                                previousVersionedState: self.versionedState,
+                                usingTransformer: self.dependencies.transformer)
         self.connectionState = connectionState
     }
     

--- a/Chatkit/Repositories/JoinedRoomsRepository.swift
+++ b/Chatkit/Repositories/JoinedRoomsRepository.swift
@@ -67,7 +67,7 @@ public class JoinedRoomsRepository: JoinedRoomsRepositoryProtocol {
         self.versionedState = buffer.currentState
         self.connectionState = connectivityMonitor.connectionState
         
-        self.state = JoinedRoomsRepository.state(forConnectionState: connectivityMonitor.connectionState,
+        self.state = Self.state(forConnectionState: connectivityMonitor.connectionState,
                                                  versionedState: buffer.currentState,
                                                  previousVersionedState: nil,
                                                  usingTransformer: dependencies.transformer)
@@ -108,7 +108,7 @@ public class JoinedRoomsRepository: JoinedRoomsRepositoryProtocol {
 extension JoinedRoomsRepository: BufferDelegate {
     
     func buffer(_ buffer: Buffer, didUpdateState state: VersionedState) {
-        self.state = JoinedRoomsRepository.state(forConnectionState: self.connectionState,
+        self.state = Self.state(forConnectionState: self.connectionState,
                                                  versionedState: state,
                                                  previousVersionedState: self.versionedState,
                                                  usingTransformer: self.dependencies.transformer)
@@ -122,7 +122,7 @@ extension JoinedRoomsRepository: BufferDelegate {
 extension JoinedRoomsRepository: ConnectivityMonitorDelegate {
     
     func connectivityMonitor(_ connectivityMonitor: ConnectivityMonitor, didUpdateConnectionState connectionState: ConnectionState) {
-        self.state = JoinedRoomsRepository.state(forConnectionState: connectionState,
+        self.state = Self.state(forConnectionState: connectionState,
                                                  versionedState: self.versionedState,
                                                  previousVersionedState: self.versionedState,
                                                  usingTransformer: self.dependencies.transformer)

--- a/Chatkit/Repositories/JoinedRoomsRepository.swift
+++ b/Chatkit/Repositories/JoinedRoomsRepository.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - Protocol
-
 /// A repository which exposes a collection of all rooms joined by the user.
 ///
 /// Construct an instance of this class using `Chatkit.createJoinedRoomsRepository(...)`
@@ -69,8 +67,8 @@ class ConcreteJoinedRoomsRepository: JoinedRoomsRepository {
     public private(set) var state: JoinedRoomsRepositoryState {
         didSet {
             if state != oldValue {
-                if let delegate = self.delegate as? JoinedRoomsViewModel {
-                    // We know that the JoinedRoomsViewModel has been coded so that it dispatches to its own
+                if let delegate = self.delegate as? ConcreteJoinedRoomsViewModel {
+                    // We know that the ConcreteJoinedRoomsViewModel has been coded so that it dispatches to its own
                     // delegate on the main thread.  So we do not need to dispatch to the main thread here.
                     delegate.joinedRoomsRepository(self, didUpdateState: state)
                 }

--- a/Chatkit/Repositories/States/JoinedRoomsRepositoryState.swift
+++ b/Chatkit/Repositories/States/JoinedRoomsRepositoryState.swift
@@ -1,42 +1,42 @@
 import Foundation
 
-    /// An enumeration representing the state of a `JoinedRoomsRepository` which serves live data
-    /// retrieved from the Chatkit web service.
-    public enum JoinedRoomsRepositoryState {
-        
-        /// The case representing a connection to the Chatkit web service that is currently being
-        /// established.
-        ///
-        /// - Parameters:
-        ///     - error: An optional error describing the problem that occurred when trying
-        ///     to establish a connection to the web service.
-        case initializing(error: Error?)
-        
-        /// The case representing an open connection to the Chatkit web service.
-        ///
-        /// - Parameters:
-        ///     - rooms: The set of all rooms joined by the user.
-        ///     - changeReason: An optional change reason, describing the last change introduced
-        ///     to the `state` of the repository.
-        case connected(rooms: Set<Room>, changeReason: JoinedRoomsRepositoryChangeReason?)
-        
-        /// The case representing a problem with the connection to the Chatkit web service.
-        ///
-        /// - Parameters:
-        ///     - rooms: The set of all rooms joined by the user.
-        ///     - error: Error describing the problem with the connection to the web service.
-        ///     - changeReason: An optional change reason, describing the last change introduced
-        ///     to the `state` of the repository.
-        case degraded(rooms: Set<Room>, error: Error, changeReason: JoinedRoomsRepositoryChangeReason?)
-        
-        /// The case representing a closed connection to the Chatkit web service.
-        ///
-        /// - Parameters:
-        ///     - error: An optional error describing the problem that caused the connection
-        ///     to the web service to close.
-        case closed(error: Error?)
-        
-    }
+/// An enumeration representing the state of a `JoinedRoomsRepository` which serves live data
+/// retrieved from the Chatkit web service.
+public enum JoinedRoomsRepositoryState {
+    
+    /// The case representing a connection to the Chatkit web service that is currently being
+    /// established.
+    ///
+    /// - Parameters:
+    ///     - error: An optional error describing the problem that occurred when trying
+    ///     to establish a connection to the web service.
+    case initializing(error: Error?)
+    
+    /// The case representing an open connection to the Chatkit web service.
+    ///
+    /// - Parameters:
+    ///     - rooms: The set of all rooms joined by the user.
+    ///     - changeReason: An optional change reason, describing the last change introduced
+    ///     to the `state` of the repository.
+    case connected(rooms: Set<Room>, changeReason: JoinedRoomsRepositoryChangeReason?)
+    
+    /// The case representing a problem with the connection to the Chatkit web service.
+    ///
+    /// - Parameters:
+    ///     - rooms: The set of all rooms joined by the user.
+    ///     - error: Error describing the problem with the connection to the web service.
+    ///     - changeReason: An optional change reason, describing the last change introduced
+    ///     to the `state` of the repository.
+    case degraded(rooms: Set<Room>, error: Error, changeReason: JoinedRoomsRepositoryChangeReason?)
+    
+    /// The case representing a closed connection to the Chatkit web service.
+    ///
+    /// - Parameters:
+    ///     - error: An optional error describing the problem that caused the connection
+    ///     to the web service to close.
+    case closed(error: Error?)
+    
+}
 
 // MARK: - Equatable
 

--- a/Chatkit/Repositories/States/JoinedRoomsRepositoryState.swift
+++ b/Chatkit/Repositories/States/JoinedRoomsRepositoryState.swift
@@ -20,7 +20,7 @@ public extension JoinedRoomsRepository {
         ///     - rooms: The set of all rooms joined by the user.
         ///     - changeReason: An optional change reason, describing the last change introduced
         ///     to the `state` of the repository.
-        case connected(rooms: Set<Room>, changeReason: ChangeReason?)
+        case connected(rooms: Set<Room>, changeReason: JoinedRoomsRepositoryChangeReason?)
         
         /// The case representing a problem with the connection to the Chatkit web service.
         ///
@@ -29,7 +29,7 @@ public extension JoinedRoomsRepository {
         ///     - error: Error describing the problem with the connection to the web service.
         ///     - changeReason: An optional change reason, describing the last change introduced
         ///     to the `state` of the repository.
-        case degraded(rooms: Set<Room>, error: Error, changeReason: ChangeReason?)
+        case degraded(rooms: Set<Room>, error: Error, changeReason: JoinedRoomsRepositoryChangeReason?)
         
         /// The case representing a closed connection to the Chatkit web service.
         ///

--- a/Chatkit/Repositories/States/JoinedRoomsRepositoryState.swift
+++ b/Chatkit/Repositories/States/JoinedRoomsRepositoryState.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-public extension JoinedRoomsRepository {
-    
     /// An enumeration representing the state of a `JoinedRoomsRepository` which serves live data
     /// retrieved from the Chatkit web service.
-    enum State {
+    public enum JoinedRoomsRepositoryState {
         
         /// The case representing a connection to the Chatkit web service that is currently being
         /// established.
@@ -39,12 +37,10 @@ public extension JoinedRoomsRepository {
         case closed(error: Error?)
         
     }
-    
-}
 
 // MARK: - Equatable
 
-extension JoinedRoomsRepository.State: Equatable {
+extension JoinedRoomsRepositoryState: Equatable {
     
     /// Returns a Boolean value indicating whether two values are equal.
     ///
@@ -54,7 +50,7 @@ extension JoinedRoomsRepository.State: Equatable {
     /// - Parameters:
     ///     - lhs: A value to compare.
     ///     - rhs: Another value to compare.
-    public static func == (lhs: JoinedRoomsRepository.State, rhs: JoinedRoomsRepository.State) -> Bool {
+    public static func == (lhs: JoinedRoomsRepositoryState, rhs: JoinedRoomsRepositoryState) -> Bool {
         switch (lhs, rhs) {
         case (let .initializing(lhsError as NSError?),
               let .initializing(rhsError as NSError?)),

--- a/Chatkit/Transformer/Transformer.swift
+++ b/Chatkit/Transformer/Transformer.swift
@@ -2,7 +2,7 @@
 protocol Transformer {
     
     func transform(state: RoomState) -> Room
-    func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepository.ChangeReason?
+    func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepositoryChangeReason?
     
 }
 
@@ -23,7 +23,7 @@ struct ConcreteTransformer: Transformer {
                     updatedAt: state.updatedAt)
     }
     
-    func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepository.ChangeReason? {
+    func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepositoryChangeReason? {
         switch currentState.signature {
         case let .addedToRoom(roomIdentifier):
             guard let currentRoom = self.room(fromState: currentState, forIdentifier: roomIdentifier) else {

--- a/Chatkit/View Models/Change Reasons/JoinedRoomsViewModelChangeReason.swift
+++ b/Chatkit/View Models/Change Reasons/JoinedRoomsViewModelChangeReason.swift
@@ -33,7 +33,7 @@ public extension JoinedRoomsViewModel {
         
         // MARK: - Initializers
         
-        internal init?(repositoryChangeReason: JoinedRoomsRepository.ChangeReason?, currentRooms: [Room], previousRooms: [Room]?) {
+        internal init?(repositoryChangeReason: JoinedRoomsRepositoryChangeReason?, currentRooms: [Room], previousRooms: [Room]?) {
             guard let repositoryChangeReason = repositoryChangeReason else {
                 return nil
             }

--- a/Chatkit/View Models/Change Reasons/JoinedRoomsViewModelChangeReason.swift
+++ b/Chatkit/View Models/Change Reasons/JoinedRoomsViewModelChangeReason.swift
@@ -1,77 +1,73 @@
 
-public extension JoinedRoomsViewModel {
+/// Enumeration that describes changes introduced to the state of `JoinedRoomsViewModel`.
+public enum JoinedRoomsViewModelChangeReason {
     
-    /// Enumeration that describes changes introduced to the state of `JoinedRoomsViewModel`.
-    enum ChangeReason {
-        
-        /// Notifies the receiver that a new room has been added to the maintened collection of rooms.
-        ///
-        /// - Parameters:
-        ///     - position: The index of the added room in the maintened collection of rooms.
-        case itemInserted(position: Int)
-        
-        /// Notifies the receiver that a room from the maintened collection of rooms has been moved.
-        ///
-        /// - Parameters:
-        ///     - fromPosition: The old index of the room before the move.
-        ///     - toPosition: The new index of the room after the move.
-        case itemMoved(fromPosition: Int, toPosition: Int)
-        
-        /// Notifies the receiver that a room from the maintened collection of rooms has been changed.
-        ///
-        /// - Parameters:
-        ///     - position: The index of the changed room in the maintened collection of rooms.
-        ///     - previousValue: The value of the room befrore it was updated.
-        case itemChanged(position: Int, previousValue: Room)
-        
-        /// Notifies the receiver that a room from the maintened collection of rooms has been removed.
-        ///
-        /// - Parameters:
-        ///     - position: The index of the removed room in the maintened collection of rooms.
-        ///     - previousValue: The value of the room befrore it was removed.
-        case itemRemoved(position: Int, previousValue: Room)
-        
-        // MARK: - Initializers
-        
-        internal init?(repositoryChangeReason: JoinedRoomsRepositoryChangeReason?, currentRooms: [Room], previousRooms: [Room]?) {
-            guard let repositoryChangeReason = repositoryChangeReason else {
-                return nil
-            }
-            
-            switch repositoryChangeReason {
-            case let .addedToRoom(room):
-                if let position = currentRooms.firstIndex(of: room) {
-                    self = .itemInserted(position: position)
-                    return
-                }
-                
-            case let .removedFromRoom(room),
-                 let .roomDeleted(room):
-                if let position = previousRooms?.firstIndex(of: room) {
-                    self = .itemRemoved(position: position, previousValue: room)
-                    return
-                }
-                
-            case let .roomUpdated(updatedRoom, previousValue),
-                 let .readStateUpdated(updatedRoom, previousValue):
-                if let currentPosition = currentRooms.firstIndex(of: updatedRoom) {
-                    if let previousPosition = previousRooms?.firstIndex(of: previousValue), currentPosition != previousPosition {
-                        self = .itemMoved(fromPosition: previousPosition, toPosition: currentPosition)
-                        return
-                    }
-                    
-                    self = .itemChanged(position: currentPosition, previousValue: previousValue)
-                    return
-                }
-            }
-            
+    /// Notifies the receiver that a new room has been added to the maintened collection of rooms.
+    ///
+    /// - Parameters:
+    ///     - position: The index of the added room in the maintened collection of rooms.
+    case itemInserted(position: Int)
+    
+    /// Notifies the receiver that a room from the maintened collection of rooms has been moved.
+    ///
+    /// - Parameters:
+    ///     - fromPosition: The old index of the room before the move.
+    ///     - toPosition: The new index of the room after the move.
+    case itemMoved(fromPosition: Int, toPosition: Int)
+    
+    /// Notifies the receiver that a room from the maintened collection of rooms has been changed.
+    ///
+    /// - Parameters:
+    ///     - position: The index of the changed room in the maintened collection of rooms.
+    ///     - previousValue: The value of the room befrore it was updated.
+    case itemChanged(position: Int, previousValue: Room)
+    
+    /// Notifies the receiver that a room from the maintened collection of rooms has been removed.
+    ///
+    /// - Parameters:
+    ///     - position: The index of the removed room in the maintened collection of rooms.
+    ///     - previousValue: The value of the room befrore it was removed.
+    case itemRemoved(position: Int, previousValue: Room)
+    
+    // MARK: - Initializers
+    
+    internal init?(repositoryChangeReason: JoinedRoomsRepositoryChangeReason?, currentRooms: [Room], previousRooms: [Room]?) {
+        guard let repositoryChangeReason = repositoryChangeReason else {
             return nil
         }
         
+        switch repositoryChangeReason {
+        case let .addedToRoom(room):
+            if let position = currentRooms.firstIndex(of: room) {
+                self = .itemInserted(position: position)
+                return
+            }
+            
+        case let .removedFromRoom(room),
+             let .roomDeleted(room):
+            if let position = previousRooms?.firstIndex(of: room) {
+                self = .itemRemoved(position: position, previousValue: room)
+                return
+            }
+            
+        case let .roomUpdated(updatedRoom, previousValue),
+             let .readStateUpdated(updatedRoom, previousValue):
+            if let currentPosition = currentRooms.firstIndex(of: updatedRoom) {
+                if let previousPosition = previousRooms?.firstIndex(of: previousValue), currentPosition != previousPosition {
+                    self = .itemMoved(fromPosition: previousPosition, toPosition: currentPosition)
+                    return
+                }
+                
+                self = .itemChanged(position: currentPosition, previousValue: previousValue)
+                return
+            }
+        }
+        
+        return nil
     }
     
 }
 
 // MARK: - Equatable
 
-extension JoinedRoomsViewModel.ChangeReason: Equatable {}
+extension JoinedRoomsViewModelChangeReason: Equatable {}

--- a/Chatkit/View Models/JoinedRoomsViewModel.swift
+++ b/Chatkit/View Models/JoinedRoomsViewModel.swift
@@ -58,7 +58,7 @@ public class JoinedRoomsViewModel {
     
     // MARK: - Private methods
     
-    private static func state(forRepositoryState repositoryState: JoinedRoomsRepository.State, previousState: State? = nil) -> State {
+    private static func state(forRepositoryState repositoryState: JoinedRoomsRepositoryState, previousState: State? = nil) -> State {
         var previousRooms: [Room]? = nil
         
         switch previousState {
@@ -82,7 +82,7 @@ public class JoinedRoomsViewModel {
 /// :nodoc:
 extension JoinedRoomsViewModel: JoinedRoomsRepositoryDelegate {
     
-    public func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepository.State) {
+    public func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepositoryState) {
         self.state = JoinedRoomsViewModel.state(forRepositoryState: state, previousState: self.state)
     }
     

--- a/Chatkit/View Models/JoinedRoomsViewModel.swift
+++ b/Chatkit/View Models/JoinedRoomsViewModel.swift
@@ -35,7 +35,7 @@ public class JoinedRoomsViewModel {
     private let repository: JoinedRoomsRepositoryProtocol
     
     /// The current state of the repository.
-    public private(set) var state: State {
+    public private(set) var state: JoinedRoomsViewModelState {
         didSet {
             if state != oldValue {
                 DispatchQueue.main.async {
@@ -51,14 +51,14 @@ public class JoinedRoomsViewModel {
     // MARK: - Initializers
     
     init(repository: JoinedRoomsRepositoryProtocol) {
-        self.state = JoinedRoomsViewModel.state(forRepositoryState: repository.state)
+        self.state = Self.state(forRepositoryState: repository.state)
         self.repository = repository
         self.repository.delegate = self
     }
     
     // MARK: - Private methods
     
-    private static func state(forRepositoryState repositoryState: JoinedRoomsRepositoryState, previousState: State? = nil) -> State {
+    private static func state(forRepositoryState repositoryState: JoinedRoomsRepositoryState, previousState: JoinedRoomsViewModelState? = nil) -> JoinedRoomsViewModelState {
         var previousRooms: [Room]? = nil
         
         switch previousState {
@@ -72,7 +72,7 @@ public class JoinedRoomsViewModel {
             break
         }
         
-        return State(repositoryState: repositoryState, previousRooms: previousRooms)
+        return JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: previousRooms)
     }
     
 }
@@ -83,7 +83,7 @@ public class JoinedRoomsViewModel {
 extension JoinedRoomsViewModel: JoinedRoomsRepositoryDelegate {
     
     public func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepositoryState) {
-        self.state = JoinedRoomsViewModel.state(forRepositoryState: state, previousState: self.state)
+        self.state = Self.state(forRepositoryState: state, previousState: self.state)
     }
     
 }
@@ -99,6 +99,6 @@ public protocol JoinedRoomsViewModelDelegate: AnyObject {
     /// - Parameters:
     ///     - joinedRoomsViewModel: The `JoinedRoomsViewModel` that called the method.
     ///     - state: The updated value of the `state`.
-    func joinedRoomsViewModel(_ joinedRoomsViewModel: JoinedRoomsViewModel, didUpdateState state: JoinedRoomsViewModel.State)
+    func joinedRoomsViewModel(_ joinedRoomsViewModel: JoinedRoomsViewModel, didUpdateState state: JoinedRoomsViewModelState)
     
 }

--- a/Chatkit/View Models/JoinedRoomsViewModel.swift
+++ b/Chatkit/View Models/JoinedRoomsViewModel.swift
@@ -28,13 +28,39 @@ import Foundation
 ///   - `.connected`: updates are flowing live, or
 ///   - `.degraded`: updates may be delayed due to network problems, or
 ///   - `.closed`: the connection is closed, no further updates available.
-public class JoinedRoomsViewModel {
+public protocol JoinedRoomsViewModel {
+    
+    /// The current state of the view model.
+    var state: JoinedRoomsViewModelState { get }
+    
+    /// The object that is notified when the `state` has changed.
+    var delegate: JoinedRoomsViewModelDelegate? { get set }
+    
+}
+
+// MARK: - Delegate
+
+/// A delegate protocol for being notified when the `state` property of a `JoinedRoomsViewModel`
+/// has changed.
+public protocol JoinedRoomsViewModelDelegate: AnyObject {
+    
+    /// Notifies the receiver that the `state` of the view model has changed.
+    ///
+    /// - Parameters:
+    ///     - joinedRoomsViewModel: The `JoinedRoomsViewModel` that called the method.
+    ///     - state: The updated value of the `state`.
+    func joinedRoomsViewModel(_ joinedRoomsViewModel: JoinedRoomsViewModel, didUpdateState state: JoinedRoomsViewModelState)
+    
+}
+
+// MARK: - Concrete implementation
+
+class ConcreteJoinedRoomsViewModel: JoinedRoomsViewModel {
     
     // MARK: - Properties
     
     private let repository: JoinedRoomsRepository
     
-    /// The current state of the view model.
     public private(set) var state: JoinedRoomsViewModelState {
         didSet {
             if state != oldValue {
@@ -45,7 +71,6 @@ public class JoinedRoomsViewModel {
         }
     }
     
-    /// The object that is notified when the `state` has changed.
     public weak var delegate: JoinedRoomsViewModelDelegate?
     
     // MARK: - Initializers
@@ -80,25 +105,10 @@ public class JoinedRoomsViewModel {
 // MARK: - JoinedRoomsRepositoryDelegate
 
 /// :nodoc:
-extension JoinedRoomsViewModel: JoinedRoomsRepositoryDelegate {
+extension ConcreteJoinedRoomsViewModel: JoinedRoomsRepositoryDelegate {
     
     public func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepositoryState) {
         self.state = Self.state(forRepositoryState: state, previousState: self.state)
     }
-    
-}
-
-// MARK: - Delegate
-
-/// A delegate protocol for being notified when the `state` property of a `JoinedRoomsViewModel`
-/// has changed.
-public protocol JoinedRoomsViewModelDelegate: AnyObject {
-    
-    /// Notifies the receiver that the `state` of the view model has changed.
-    ///
-    /// - Parameters:
-    ///     - joinedRoomsViewModel: The `JoinedRoomsViewModel` that called the method.
-    ///     - state: The updated value of the `state`.
-    func joinedRoomsViewModel(_ joinedRoomsViewModel: JoinedRoomsViewModel, didUpdateState state: JoinedRoomsViewModelState)
     
 }

--- a/Chatkit/View Models/JoinedRoomsViewModel.swift
+++ b/Chatkit/View Models/JoinedRoomsViewModel.swift
@@ -32,9 +32,9 @@ public class JoinedRoomsViewModel {
     
     // MARK: - Properties
     
-    private let repository: JoinedRoomsRepositoryProtocol
+    private let repository: JoinedRoomsRepository
     
-    /// The current state of the repository.
+    /// The current state of the view model.
     public private(set) var state: JoinedRoomsViewModelState {
         didSet {
             if state != oldValue {
@@ -50,7 +50,7 @@ public class JoinedRoomsViewModel {
     
     // MARK: - Initializers
     
-    init(repository: JoinedRoomsRepositoryProtocol) {
+    init(repository: JoinedRoomsRepository) {
         self.state = Self.state(forRepositoryState: repository.state)
         self.repository = repository
         self.repository.delegate = self

--- a/Chatkit/View Models/States/JoinedRoomsViewModelState.swift
+++ b/Chatkit/View Models/States/JoinedRoomsViewModelState.swift
@@ -1,96 +1,92 @@
 import Foundation
 
-public extension JoinedRoomsViewModel {
+/// An enumeration representing the state of a `JoinedRoomsViewModel` which serves live data
+/// retrieved from the Chatkit web service.
+public enum JoinedRoomsViewModelState {
     
-    /// An enumeration representing the state of a `JoinedRoomsViewModel` which serves live data
-    /// retrieved from the Chatkit web service.
-    enum State {
-        
-        /// The case representing a connection to the Chatkit web service that is currently being
-        /// established.
-        ///
-        /// - Parameters:
-        ///     - error: An optional error describing the problem that occurred when trying
-        ///     to establish a connection to the web service.
-        case initializing(error: Error?)
-        
-        /// The case representing an open connection to the Chatkit web service.
-        ///
-        /// - Parameters:
-        ///     - rooms: The array of all rooms joined by the user.
-        ///     - changeReason: An optional change reason, describing the last change introduced
-        ///     to the `state` of the view model.
-        case connected(rooms: [Room], changeReason: JoinedRoomsViewModelChangeReason?)
-        
-        /// The case representing a problem with the connection to the Chatkit web service.
-        ///
-        /// - Parameters:
-        ///     - rooms: The array of all rooms joined by the user.
-        ///     - error: Error describing the problem with the connection to the web service.
-        ///     - changeReason: An optional change reason, describing the last change introduced
-        ///     to the `state` of the view model.
-        case degraded(rooms: [Room], error: Error, changeReason: JoinedRoomsViewModelChangeReason?)
-        
-        /// The case representing a closed connection to the Chatkit web service.
-        ///
-        /// - Parameters:
-        ///     - error: An optional error describing the problem that caused the connection
-        ///     to the web service to close.
-        case closed(error: Error?)
-        
-        // MARK: - Initializers
-        
-        internal init(repositoryState: JoinedRoomsRepositoryState, previousRooms: [Room]?) {
-            switch repositoryState {
-            case let .initializing(error):
-                self = .initializing(error: error)
-                
-            case let .connected(rooms, repositoryChangeReason):
-                let sortedRooms = State.sortedRooms(rooms)
-                let changeReason = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason,
-                                                                    currentRooms: sortedRooms,
-                                                                    previousRooms: previousRooms)
-                
-                self = .connected(rooms: sortedRooms, changeReason: changeReason)
-                
-            case let .degraded(rooms, error, repositoryChangeReason):
-                let sortedRooms = State.sortedRooms(rooms)
-                let changeReason = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason,
-                                                                    currentRooms: sortedRooms,
-                                                                    previousRooms: previousRooms)
-                
-                self = .degraded(rooms: sortedRooms, error: error, changeReason: changeReason)
-                
-            case let .closed(error):
-                self = .closed(error: error)
-            }
+    /// The case representing a connection to the Chatkit web service that is currently being
+    /// established.
+    ///
+    /// - Parameters:
+    ///     - error: An optional error describing the problem that occurred when trying
+    ///     to establish a connection to the web service.
+    case initializing(error: Error?)
+    
+    /// The case representing an open connection to the Chatkit web service.
+    ///
+    /// - Parameters:
+    ///     - rooms: The array of all rooms joined by the user.
+    ///     - changeReason: An optional change reason, describing the last change introduced
+    ///     to the `state` of the view model.
+    case connected(rooms: [Room], changeReason: JoinedRoomsViewModelChangeReason?)
+    
+    /// The case representing a problem with the connection to the Chatkit web service.
+    ///
+    /// - Parameters:
+    ///     - rooms: The array of all rooms joined by the user.
+    ///     - error: Error describing the problem with the connection to the web service.
+    ///     - changeReason: An optional change reason, describing the last change introduced
+    ///     to the `state` of the view model.
+    case degraded(rooms: [Room], error: Error, changeReason: JoinedRoomsViewModelChangeReason?)
+    
+    /// The case representing a closed connection to the Chatkit web service.
+    ///
+    /// - Parameters:
+    ///     - error: An optional error describing the problem that caused the connection
+    ///     to the web service to close.
+    case closed(error: Error?)
+    
+    // MARK: - Initializers
+    
+    internal init(repositoryState: JoinedRoomsRepositoryState, previousRooms: [Room]?) {
+        switch repositoryState {
+        case let .initializing(error):
+            self = .initializing(error: error)
+            
+        case let .connected(rooms, repositoryChangeReason):
+            let sortedRooms = Self.sortedRooms(rooms)
+            let changeReason = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason,
+                                                                currentRooms: sortedRooms,
+                                                                previousRooms: previousRooms)
+            
+            self = .connected(rooms: sortedRooms, changeReason: changeReason)
+            
+        case let .degraded(rooms, error, repositoryChangeReason):
+            let sortedRooms = Self.sortedRooms(rooms)
+            let changeReason = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason,
+                                                                currentRooms: sortedRooms,
+                                                                previousRooms: previousRooms)
+            
+            self = .degraded(rooms: sortedRooms, error: error, changeReason: changeReason)
+            
+        case let .closed(error):
+            self = .closed(error: error)
         }
-        
-        // MARK: - Private methods
-        
-        private static func sortedRooms(_ rooms: Set<Room>) -> [Room] {
-            return rooms.sorted { lhs, rhs -> Bool in
-                if lhs.lastMessageAt == nil && rhs.lastMessageAt != nil {
-                    return true
-                }
-                else if lhs.lastMessageAt != nil && rhs.lastMessageAt == nil {
-                    return false
-                }
-                else if let lhsLastMessageAt = lhs.lastMessageAt, let rhsLastMessageAt = rhs.lastMessageAt {
-                    return lhsLastMessageAt > rhsLastMessageAt
-                }
-                
-                return lhs.createdAt > rhs.createdAt
+    }
+    
+    // MARK: - Private methods
+    
+    private static func sortedRooms(_ rooms: Set<Room>) -> [Room] {
+        return rooms.sorted { lhs, rhs -> Bool in
+            if lhs.lastMessageAt == nil && rhs.lastMessageAt != nil {
+                return true
             }
+            else if lhs.lastMessageAt != nil && rhs.lastMessageAt == nil {
+                return false
+            }
+            else if let lhsLastMessageAt = lhs.lastMessageAt, let rhsLastMessageAt = rhs.lastMessageAt {
+                return lhsLastMessageAt > rhsLastMessageAt
+            }
+            
+            return lhs.createdAt > rhs.createdAt
         }
-        
     }
     
 }
 
 // MARK: - Equatable
 
-extension JoinedRoomsViewModel.State: Equatable {
+extension JoinedRoomsViewModelState: Equatable {
     
     /// Returns a Boolean value indicating whether two values are equal.
     ///
@@ -100,7 +96,7 @@ extension JoinedRoomsViewModel.State: Equatable {
     /// - Parameters:
     ///     - lhs: A value to compare.
     ///     - rhs: Another value to compare.
-    public static func == (lhs: JoinedRoomsViewModel.State, rhs: JoinedRoomsViewModel.State) -> Bool {
+    public static func == (lhs: JoinedRoomsViewModelState, rhs: JoinedRoomsViewModelState) -> Bool {
         switch (lhs, rhs) {
         case (let .initializing(lhsError as NSError?),
               let .initializing(rhsError as NSError?)),

--- a/Chatkit/View Models/States/JoinedRoomsViewModelState.swift
+++ b/Chatkit/View Models/States/JoinedRoomsViewModelState.swift
@@ -20,7 +20,7 @@ public extension JoinedRoomsViewModel {
         ///     - rooms: The array of all rooms joined by the user.
         ///     - changeReason: An optional change reason, describing the last change introduced
         ///     to the `state` of the view model.
-        case connected(rooms: [Room], changeReason: ChangeReason?)
+        case connected(rooms: [Room], changeReason: JoinedRoomsViewModelChangeReason?)
         
         /// The case representing a problem with the connection to the Chatkit web service.
         ///
@@ -29,7 +29,7 @@ public extension JoinedRoomsViewModel {
         ///     - error: Error describing the problem with the connection to the web service.
         ///     - changeReason: An optional change reason, describing the last change introduced
         ///     to the `state` of the view model.
-        case degraded(rooms: [Room], error: Error, changeReason: ChangeReason?)
+        case degraded(rooms: [Room], error: Error, changeReason: JoinedRoomsViewModelChangeReason?)
         
         /// The case representing a closed connection to the Chatkit web service.
         ///
@@ -47,13 +47,17 @@ public extension JoinedRoomsViewModel {
                 
             case let .connected(rooms, repositoryChangeReason):
                 let sortedRooms = State.sortedRooms(rooms)
-                let changeReason = ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: sortedRooms, previousRooms: previousRooms)
+                let changeReason = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason,
+                                                                    currentRooms: sortedRooms,
+                                                                    previousRooms: previousRooms)
                 
                 self = .connected(rooms: sortedRooms, changeReason: changeReason)
                 
             case let .degraded(rooms, error, repositoryChangeReason):
                 let sortedRooms = State.sortedRooms(rooms)
-                let changeReason = ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: sortedRooms, previousRooms: previousRooms)
+                let changeReason = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason,
+                                                                    currentRooms: sortedRooms,
+                                                                    previousRooms: previousRooms)
                 
                 self = .degraded(rooms: sortedRooms, error: error, changeReason: changeReason)
                 

--- a/Chatkit/View Models/States/JoinedRoomsViewModelState.swift
+++ b/Chatkit/View Models/States/JoinedRoomsViewModelState.swift
@@ -40,7 +40,7 @@ public extension JoinedRoomsViewModel {
         
         // MARK: - Initializers
         
-        internal init(repositoryState: JoinedRoomsRepository.State, previousRooms: [Room]?) {
+        internal init(repositoryState: JoinedRoomsRepositoryState, previousRooms: [Room]?) {
             switch repositoryState {
             case let .initializing(error):
                 self = .initializing(error: error)

--- a/Test Utilities/Doubles/Repositories/JoinedRoomsRepository.swift
+++ b/Test Utilities/Doubles/Repositories/JoinedRoomsRepository.swift
@@ -3,7 +3,7 @@ import XCTest
 
 public class StubJoinedRoomsRepository: DoubleBase, JoinedRoomsRepositoryProtocol {
     
-    private let state_toReturn: JoinedRoomsRepository.State
+    private let state_toReturn: JoinedRoomsRepositoryState
     public private(set) var state_actualCallCount: UInt = 0
     
     private let delegate_expectedSetCallCount: UInt
@@ -19,7 +19,7 @@ public class StubJoinedRoomsRepository: DoubleBase, JoinedRoomsRepositoryProtoco
         }
     }
     
-    public init(state_toReturn: JoinedRoomsRepository.State,
+    public init(state_toReturn: JoinedRoomsRepositoryState,
                 delegate_expectedSetCallCount: UInt = 0,
                 file: StaticString = #file, line: UInt = #line) {
         
@@ -29,12 +29,12 @@ public class StubJoinedRoomsRepository: DoubleBase, JoinedRoomsRepositoryProtoco
         super.init(file: file, line: line)
     }
     
-    public var state: JoinedRoomsRepository.State {
+    public var state: JoinedRoomsRepositoryState {
         self.state_actualCallCount += 1
         return self.state_toReturn
     }
     
-    public func report(_ state: JoinedRoomsRepository.State) {
+    public func report(_ state: JoinedRoomsRepositoryState) {
         let room = Room(identifier: "room-identifier",
                         name: "room-name",
                         isPrivate: false,

--- a/Test Utilities/Doubles/Repositories/JoinedRoomsRepository.swift
+++ b/Test Utilities/Doubles/Repositories/JoinedRoomsRepository.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import PusherChatkit
 
-public class StubJoinedRoomsRepository: DoubleBase, JoinedRoomsRepositoryProtocol {
+public class StubJoinedRoomsRepository: DoubleBase, JoinedRoomsRepository {
     
     private let state_toReturn: JoinedRoomsRepositoryState
     public private(set) var state_actualCallCount: UInt = 0
@@ -35,26 +35,7 @@ public class StubJoinedRoomsRepository: DoubleBase, JoinedRoomsRepositoryProtoco
     }
     
     public func report(_ state: JoinedRoomsRepositoryState) {
-        let room = Room(identifier: "room-identifier",
-                        name: "room-name",
-                        isPrivate: false,
-                        unreadCount: 10,
-                        lastMessageAt: nil,
-                        customData: nil,
-                        createdAt: .distantPast,
-                        updatedAt: .distantPast)
-        
-        let stubBuffer = StubBuffer(currentState_toReturn: nil, delegate_expectedSetCallCount: 1)
-        let stubConnectivityMonitor = StubConnectivityMonitor(subscriptionType_toReturn: .user,
-                                                              connectionState_toReturn: .connected,
-                                                              delegate_expectedSetCallCount: 1)
-        let stubTransformer = StubTransformer(room_toReturn: room, transformCurrentStatePreviousState_expectedSetCallCount: 1)
-        
-        let dependencies = DependenciesDoubles(transformer: stubTransformer)
-        
-        let joinedRoomsRepository = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
-        
-        self.delegate?.joinedRoomsRepository(joinedRoomsRepository, didUpdateState: state)
+        self.delegate?.joinedRoomsRepository(self, didUpdateState: state)
     }
     
 }

--- a/Test Utilities/Doubles/Repositories/JoinedRoomsRepositoryDelegate.swift
+++ b/Test Utilities/Doubles/Repositories/JoinedRoomsRepositoryDelegate.swift
@@ -4,7 +4,7 @@ import XCTest
 public class StubJoinedRoomsRepositoryDelegate: DoubleBase, JoinedRoomsRepositoryDelegate {
     
     private var didUpdateState_expectedCallCount: UInt
-    public private(set) var didUpdateState_stateLastReceived: JoinedRoomsRepository.State?
+    public private(set) var didUpdateState_stateLastReceived: JoinedRoomsRepositoryState?
     public private(set) var didUpdateState_actualCallCount: UInt = 0
     
     public init(didUpdateState_expectedCallCount: UInt = 0,
@@ -14,7 +14,7 @@ public class StubJoinedRoomsRepositoryDelegate: DoubleBase, JoinedRoomsRepositor
         super.init(file: file, line: line)
     }
     
-    public func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepository.State) {
+    public func joinedRoomsRepository(_ joinedRoomsRepository: JoinedRoomsRepository, didUpdateState state: JoinedRoomsRepositoryState) {
         didUpdateState_stateLastReceived = state
         didUpdateState_actualCallCount += 1
         

--- a/Test Utilities/Doubles/Transformer/Transformer.swift
+++ b/Test Utilities/Doubles/Transformer/Transformer.swift
@@ -15,7 +15,7 @@ public class DummyTransformer: DummyBase, Transformer {
                     updatedAt: Date())
     }
     
-    public func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepository.ChangeReason? {
+    public func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepositoryChangeReason? {
         DummyFail(sender: self, function: #function)
         return nil
     }
@@ -28,14 +28,14 @@ public class StubTransformer: DoubleBase, Transformer {
     private let transformState_expectedSetCallCount: UInt
     public private(set) var transformState_actualSetCallCount: UInt = 0
     
-    private let changeReason_toReturn: JoinedRoomsRepository.ChangeReason?
+    private let changeReason_toReturn: JoinedRoomsRepositoryChangeReason?
     private let transformCurrentStatePreviousState_expectedSetCallCount: UInt
     public private(set) var transformCurrentStatePreviousState_actualSetCallCount: UInt = 0
     
     
     
     public init(room_toReturn: Room,
-                changeReason_toReturn: JoinedRoomsRepository.ChangeReason? = nil,
+                changeReason_toReturn: JoinedRoomsRepositoryChangeReason? = nil,
                 transformState_expectedSetCallCount: UInt = 0,
                 transformCurrentStatePreviousState_expectedSetCallCount: UInt = 0,
                 file: StaticString = #file, line: UInt = #line) {
@@ -59,7 +59,7 @@ public class StubTransformer: DoubleBase, Transformer {
         return self.room_toReturn
     }
     
-    public func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepository.ChangeReason? {
+    public func transform(currentState: VersionedState, previousState: VersionedState?) -> JoinedRoomsRepositoryChangeReason? {
         self.transformCurrentStatePreviousState_actualSetCallCount += 1
         
         guard self.transformCurrentStatePreviousState_actualSetCallCount <= self.transformCurrentStatePreviousState_expectedSetCallCount else {

--- a/Test Utilities/Doubles/View Models/JoinedRoomsViewModelDelegate.swift
+++ b/Test Utilities/Doubles/View Models/JoinedRoomsViewModelDelegate.swift
@@ -4,7 +4,7 @@ import XCTest
 public class StubJoinedRoomsViewModelDelegate: DoubleBase, JoinedRoomsViewModelDelegate {
     
     private var didUpdateState_expectedCallCount: UInt
-    public private(set) var didUpdateState_stateLastReceived: JoinedRoomsViewModel.State?
+    public private(set) var didUpdateState_stateLastReceived: JoinedRoomsViewModelState?
     public private(set) var didUpdateState_actualCallCount: UInt = 0
     
     public init(didUpdateState_expectedCallCount: UInt = 0,
@@ -14,7 +14,7 @@ public class StubJoinedRoomsViewModelDelegate: DoubleBase, JoinedRoomsViewModelD
         super.init(file: file, line: line)
     }
     
-    public func joinedRoomsViewModel(_ joinedRoomsViewModel: JoinedRoomsViewModel, didUpdateState state: JoinedRoomsViewModel.State) {
+    public func joinedRoomsViewModel(_ joinedRoomsViewModel: JoinedRoomsViewModel, didUpdateState state: JoinedRoomsViewModelState) {
         didUpdateState_stateLastReceived = state
         didUpdateState_actualCallCount += 1
         

--- a/Unit Tests/Tests/Repositories/ConcreteJoinedRoomsRepositoryTests.swift
+++ b/Unit Tests/Tests/Repositories/ConcreteJoinedRoomsRepositoryTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import TestUtilities
 @testable import PusherChatkit
 
-class JoinedRoomsRepositoryTests: XCTestCase {
+class ConcreteJoinedRoomsRepositoryTests: XCTestCase {
     
     // MARK: - Properties
     
@@ -52,7 +52,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         
         /******************/
         /*----- THEN -----*/
@@ -119,7 +119,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         
         /******************/
         /*----- THEN -----*/
@@ -166,7 +166,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         
         /******************/
         /*----- THEN -----*/
@@ -212,7 +212,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         
         /******************/
         /*----- THEN -----*/
@@ -247,7 +247,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         
         /******************/
         /*----- THEN -----*/
@@ -293,7 +293,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         
         let dependencies = DependenciesDoubles(transformer: stubTransformer)
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         sut.delegate = stubDelegate
         
         let expectation = XCTestExpectation(description: "Delegate called")
@@ -356,7 +356,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         
         let dependencies = DependenciesDoubles(transformer: stubTransformer)
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         sut.delegate = stubDelegate
         
         XCTAssertEqual(sut.state, .initializing(error: nil))
@@ -442,7 +442,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         
         let dependencies = DependenciesDoubles(transformer: stubTransformer)
         
-        let sut = JoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
+        let sut = ConcreteJoinedRoomsRepository(buffer: stubBuffer, connectivityMonitor: stubConnectivityMonitor, dependencies: dependencies)
         sut.delegate = stubDelegate
         
         XCTAssertEqual(sut.state,

--- a/Unit Tests/Tests/Repositories/Filters/ConcreteJoinedRoomsRepositoryFilterTests.swift
+++ b/Unit Tests/Tests/Repositories/Filters/ConcreteJoinedRoomsRepositoryFilterTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import PusherChatkit
 
-class JoinedRoomsFilterTests: XCTestCase {
+class ConcreteJoinedRoomsRepositoryFilterTests: XCTestCase {
     
     // MARK: - Tests
     
@@ -42,7 +42,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let newState = oldState
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -125,7 +125,7 @@ class JoinedRoomsFilterTests: XCTestCase {
             signature: .subscriptionStateUpdated
         )
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -186,7 +186,7 @@ class JoinedRoomsFilterTests: XCTestCase {
             signature: .roomDeleted(roomIdentifier: "test-identifier")
         )
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -236,7 +236,7 @@ class JoinedRoomsFilterTests: XCTestCase {
             signature: .initialState
         )
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -290,7 +290,7 @@ class JoinedRoomsFilterTests: XCTestCase {
             signature: .initialState
         )
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -313,7 +313,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let signature:  VersionSignature = .initialState
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -336,7 +336,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let signature:  VersionSignature = .addedToRoom(roomIdentifier: "room-identifier")
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -359,7 +359,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let signature:  VersionSignature = .removedFromRoom(roomIdentifier: "room-identifier")
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -382,7 +382,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let signature:  VersionSignature = .roomUpdated(roomIdentifier: "room-identifier")
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -405,7 +405,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let signature:  VersionSignature = .roomDeleted(roomIdentifier: "room-identifier")
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -428,7 +428,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let signature:  VersionSignature = .readStateUpdated(roomIdentifier: "room-identifier")
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/
@@ -451,7 +451,7 @@ class JoinedRoomsFilterTests: XCTestCase {
         
         let signature:  VersionSignature = .unsigned
         
-        let sut = JoinedRoomsRepository.Filter()
+        let sut = ConcreteJoinedRoomsRepository.Filter()
         
         /******************/
         /*----- WHEN -----*/

--- a/Unit Tests/Tests/Repositories/JoinedRoomsRepositoryTests.swift
+++ b/Unit Tests/Tests/Repositories/JoinedRoomsRepositoryTests.swift
@@ -58,7 +58,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsRepository.State = .initializing(error: nil)
+        let expectedState: JoinedRoomsRepositoryState = .initializing(error: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -125,7 +125,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsRepository.State = .connected(rooms: [self.room], changeReason: nil)
+        let expectedState: JoinedRoomsRepositoryState = .connected(rooms: [self.room], changeReason: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -172,7 +172,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsRepository.State = .degraded(rooms: [], error: errorToReturn, changeReason: nil)
+        let expectedState: JoinedRoomsRepositoryState = .degraded(rooms: [], error: errorToReturn, changeReason: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -218,7 +218,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsRepository.State = .closed(error: nil)
+        let expectedState: JoinedRoomsRepositoryState = .closed(error: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -253,7 +253,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsRepository.State = .initializing(error: nil)
+        let expectedState: JoinedRoomsRepositoryState = .initializing(error: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -315,7 +315,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         
         wait(for: [expectation], timeout: 1.0)
         
-        let expectedState: JoinedRoomsRepository.State = .closed(error: nil)
+        let expectedState: JoinedRoomsRepositoryState = .closed(error: nil)
         
         XCTAssertEqual(stubDelegate.didUpdateState_actualCallCount, 1)
         XCTAssertEqual(stubDelegate.didUpdateState_stateLastReceived, expectedState)
@@ -372,7 +372,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsRepository.State = .closed(error: nil)
+        let expectedState: JoinedRoomsRepositoryState = .closed(error: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -459,7 +459,7 @@ class JoinedRoomsRepositoryTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsRepository.State = .connected(rooms: [self.room], changeReason: nil)
+        let expectedState: JoinedRoomsRepositoryState = .connected(rooms: [self.room], changeReason: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }

--- a/Unit Tests/Tests/Repositories/States/JoinedRoomsRepositoryStateTests.swift
+++ b/Unit Tests/Tests/Repositories/States/JoinedRoomsRepositoryStateTests.swift
@@ -56,10 +56,10 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let initializingState: JoinedRoomsRepository.State = .initializing(error: self.firstError)
-        let connectedState: JoinedRoomsRepository.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let degradedState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let closedState: JoinedRoomsRepository.State = .closed(error: self.firstError)
+        let initializingState: JoinedRoomsRepositoryState = .initializing(error: self.firstError)
+        let connectedState: JoinedRoomsRepositoryState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let degradedState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let closedState: JoinedRoomsRepositoryState = .closed(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -94,8 +94,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .initializing(error: self.firstError)
-        let secondState: JoinedRoomsRepository.State = .initializing(error: self.firstError)
+        let firstState: JoinedRoomsRepositoryState = .initializing(error: self.firstError)
+        let secondState: JoinedRoomsRepositoryState = .initializing(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -116,8 +116,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .initializing(error: self.firstError)
-        let secondState: JoinedRoomsRepository.State = .initializing(error: self.secondError)
+        let firstState: JoinedRoomsRepositoryState = .initializing(error: self.firstError)
+        let secondState: JoinedRoomsRepositoryState = .initializing(error: self.secondError)
         
         /******************/
         /*----- WHEN -----*/
@@ -138,8 +138,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .closed(error: self.firstError)
-        let secondState: JoinedRoomsRepository.State = .closed(error: self.firstError)
+        let firstState: JoinedRoomsRepositoryState = .closed(error: self.firstError)
+        let secondState: JoinedRoomsRepositoryState = .closed(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -160,8 +160,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .closed(error: self.firstError)
-        let secondState: JoinedRoomsRepository.State = .closed(error: self.secondError)
+        let firstState: JoinedRoomsRepositoryState = .closed(error: self.firstError)
+        let secondState: JoinedRoomsRepositoryState = .closed(error: self.secondError)
         
         /******************/
         /*----- WHEN -----*/
@@ -182,8 +182,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsRepository.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsRepositoryState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsRepositoryState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -204,8 +204,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsRepository.State = .connected(rooms: self.secondRooms, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsRepositoryState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsRepositoryState = .connected(rooms: self.secondRooms, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -226,8 +226,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsRepository.State = .connected(rooms: self.firstRooms, changeReason: self.secondChangeReason)
+        let firstState: JoinedRoomsRepositoryState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsRepositoryState = .connected(rooms: self.firstRooms, changeReason: self.secondChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -248,8 +248,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -270,8 +270,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsRepository.State = .degraded(rooms: self.secondRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsRepositoryState = .degraded(rooms: self.secondRooms, error: self.firstError, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -292,8 +292,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.secondError, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.secondError, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -314,8 +314,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsRepository.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.secondChangeReason)
+        let firstState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsRepositoryState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.secondChangeReason)
         
         /******************/
         /*----- WHEN -----*/

--- a/Unit Tests/Tests/Repositories/States/JoinedRoomsRepositoryStateTests.swift
+++ b/Unit Tests/Tests/Repositories/States/JoinedRoomsRepositoryStateTests.swift
@@ -9,8 +9,8 @@ class JoinedRoomsRepositoryStateTests: XCTestCase {
     var firstRooms: Set<Room>!
     var secondRooms: Set<Room>!
     
-    var firstChangeReason: JoinedRoomsRepository.ChangeReason!
-    var secondChangeReason: JoinedRoomsRepository.ChangeReason!
+    var firstChangeReason: JoinedRoomsRepositoryChangeReason!
+    var secondChangeReason: JoinedRoomsRepositoryChangeReason!
     
     var firstError: Error!
     var secondError: Error!

--- a/Unit Tests/Tests/Transformers/ConcreteTransformerTests.swift
+++ b/Unit Tests/Tests/Transformers/ConcreteTransformerTests.swift
@@ -129,7 +129,7 @@ class ConcreteTransformerTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedChangeReason: JoinedRoomsRepository.ChangeReason = .addedToRoom(
+        let expectedChangeReason: JoinedRoomsRepositoryChangeReason = .addedToRoom(
             room: Room(
                 identifier: roomIdentifier,
                 name: "room-name",
@@ -230,7 +230,7 @@ class ConcreteTransformerTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedChangeReason: JoinedRoomsRepository.ChangeReason = .removedFromRoom(
+        let expectedChangeReason: JoinedRoomsRepositoryChangeReason = .removedFromRoom(
             room: Room(
                 identifier: roomIdentifier,
                 name: "room-name",
@@ -356,7 +356,7 @@ class ConcreteTransformerTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedChangeReason: JoinedRoomsRepository.ChangeReason = .roomUpdated(
+        let expectedChangeReason: JoinedRoomsRepositoryChangeReason = .roomUpdated(
             updatedRoom: Room(
                 identifier: roomIdentifier,
                 name: "new-room-name",
@@ -558,7 +558,7 @@ class ConcreteTransformerTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedChangeReason: JoinedRoomsRepository.ChangeReason = .roomDeleted(
+        let expectedChangeReason: JoinedRoomsRepositoryChangeReason = .roomDeleted(
             room: Room(
                 identifier: roomIdentifier,
                 name: "room-name",
@@ -684,7 +684,7 @@ class ConcreteTransformerTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedChangeReason: JoinedRoomsRepository.ChangeReason = .readStateUpdated(
+        let expectedChangeReason: JoinedRoomsRepositoryChangeReason = .readStateUpdated(
             updatedRoom: Room(
                 identifier: roomIdentifier,
                 name: "new-room-name",

--- a/Unit Tests/Tests/View Models/Change Reasons/JoinedRoomsViewModelChangeReasonTests.swift
+++ b/Unit Tests/Tests/View Models/Change Reasons/JoinedRoomsViewModelChangeReasonTests.swift
@@ -42,7 +42,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = nil
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = nil
         let currentRooms: [Room] = []
         let previousRooms: [Room]? = nil
         
@@ -65,7 +65,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .addedToRoom(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .addedToRoom(room: self.secondRoom)
         let currentRooms: [Room] = [
             self.firstRoom,
             self.secondRoom
@@ -93,7 +93,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .addedToRoom(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .addedToRoom(room: self.secondRoom)
         let currentRooms: [Room] = [
             self.firstRoom
         ]
@@ -118,7 +118,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .removedFromRoom(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .removedFromRoom(room: self.secondRoom)
         let currentRooms: [Room] = []
         let previousRooms: [Room]? = [
             self.firstRoom,
@@ -146,7 +146,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .removedFromRoom(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .removedFromRoom(room: self.secondRoom)
         let currentRooms: [Room] = []
         let previousRooms: [Room]? = [
             self.firstRoom
@@ -171,7 +171,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .removedFromRoom(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .removedFromRoom(room: self.secondRoom)
         let currentRooms: [Room] = []
         let previousRooms: [Room]? = nil
         
@@ -194,7 +194,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .roomDeleted(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .roomDeleted(room: self.secondRoom)
         let currentRooms: [Room] = []
         let previousRooms: [Room]? = [
             self.firstRoom,
@@ -222,7 +222,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .roomDeleted(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .roomDeleted(room: self.secondRoom)
         let currentRooms: [Room] = []
         let previousRooms: [Room]? = [
             self.firstRoom
@@ -247,7 +247,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .roomDeleted(room: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .roomDeleted(room: self.secondRoom)
         let currentRooms: [Room] = []
         let previousRooms: [Room]? = nil
         
@@ -270,7 +270,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .roomUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .roomUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
         let currentRooms: [Room] = [
             self.firstRoom,
             self.modifiedSecondRoom
@@ -301,7 +301,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .roomUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .roomUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
         let currentRooms: [Room] = [
             self.modifiedSecondRoom,
             self.firstRoom
@@ -332,7 +332,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .roomUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .roomUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
         let currentRooms: [Room] = [
             self.firstRoom
         ]
@@ -360,7 +360,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .readStateUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .readStateUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
         let currentRooms: [Room] = [
             self.firstRoom,
             self.modifiedSecondRoom
@@ -391,7 +391,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .readStateUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .readStateUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
         let currentRooms: [Room] = [
             self.modifiedSecondRoom,
             self.firstRoom
@@ -422,7 +422,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryChangeReason: JoinedRoomsRepository.ChangeReason? = .readStateUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
+        let repositoryChangeReason: JoinedRoomsRepositoryChangeReason? = .readStateUpdated(updatedRoom: self.modifiedSecondRoom, previousValue: self.secondRoom)
         let currentRooms: [Room] = [
             self.firstRoom
         ]

--- a/Unit Tests/Tests/View Models/Change Reasons/JoinedRoomsViewModelChangeReasonTests.swift
+++ b/Unit Tests/Tests/View Models/Change Reasons/JoinedRoomsViewModelChangeReasonTests.swift
@@ -50,7 +50,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
@@ -76,13 +76,13 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.ChangeReason = .itemInserted(position: 1)
+        let expectedValue: JoinedRoomsViewModelChangeReason = .itemInserted(position: 1)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -103,7 +103,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
@@ -129,13 +129,13 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.ChangeReason = .itemRemoved(position: 1, previousValue: self.secondRoom)
+        let expectedValue: JoinedRoomsViewModelChangeReason = .itemRemoved(position: 1, previousValue: self.secondRoom)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -156,7 +156,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
@@ -179,7 +179,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
@@ -205,13 +205,13 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.ChangeReason = .itemRemoved(position: 1, previousValue: self.secondRoom)
+        let expectedValue: JoinedRoomsViewModelChangeReason = .itemRemoved(position: 1, previousValue: self.secondRoom)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -232,7 +232,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
@@ -255,7 +255,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
@@ -284,13 +284,13 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.ChangeReason = .itemChanged(position: 1, previousValue: self.secondRoom)
+        let expectedValue: JoinedRoomsViewModelChangeReason = .itemChanged(position: 1, previousValue: self.secondRoom)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -315,13 +315,13 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.ChangeReason = .itemMoved(fromPosition: 1, toPosition: 0)
+        let expectedValue: JoinedRoomsViewModelChangeReason = .itemMoved(fromPosition: 1, toPosition: 0)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -345,7 +345,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
@@ -374,13 +374,13 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.ChangeReason = .itemChanged(position: 1, previousValue: self.secondRoom)
+        let expectedValue: JoinedRoomsViewModelChangeReason = .itemChanged(position: 1, previousValue: self.secondRoom)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -405,13 +405,13 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.ChangeReason = .itemMoved(fromPosition: 1, toPosition: 0)
+        let expectedValue: JoinedRoomsViewModelChangeReason = .itemMoved(fromPosition: 1, toPosition: 0)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -435,7 +435,7 @@ class JoinedRoomsViewModelChangeReasonTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.ChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
+        let result = JoinedRoomsViewModelChangeReason(repositoryChangeReason: repositoryChangeReason, currentRooms: currentRooms, previousRooms: previousRooms)
         
         /******************/
         /*----- THEN -----*/

--- a/Unit Tests/Tests/View Models/ConcreteJoinedRoomsViewModelTests.swift
+++ b/Unit Tests/Tests/View Models/ConcreteJoinedRoomsViewModelTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import TestUtilities
 @testable import PusherChatkit
 
-class JoinedRoomsViewModelTests: XCTestCase {
+class ConcreteJoinedRoomsViewModelTests: XCTestCase {
     
     // MARK: - Properties
     
@@ -31,7 +31,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        _ = JoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
+        _ = ConcreteJoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
         
         /******************/
         /*----- THEN -----*/
@@ -54,7 +54,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let sut = JoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
+        let sut = ConcreteJoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
         
         /******************/
         /*----- THEN -----*/
@@ -77,7 +77,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         let stubJoinedRoomsRepository = StubJoinedRoomsRepository(state_toReturn: initialStateToReturn, delegate_expectedSetCallCount: 1)
         let stubDelegate = StubJoinedRoomsViewModelDelegate(didUpdateState_expectedCallCount: 1)
         
-        let sut = JoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
+        let sut = ConcreteJoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
         sut.delegate = stubDelegate
         
         let expectation = XCTestExpectation(description: "Delegate called")
@@ -117,7 +117,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         let stubJoinedRoomsRepository = StubJoinedRoomsRepository(state_toReturn: initialStateToReturn, delegate_expectedSetCallCount: 1)
         let stubDelegate = StubJoinedRoomsViewModelDelegate(didUpdateState_expectedCallCount: 1)
         
-        let sut = JoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
+        let sut = ConcreteJoinedRoomsViewModel(repository: stubJoinedRoomsRepository)
         sut.delegate = stubDelegate
         
         let expectation = XCTestExpectation(description: "Delegate called")

--- a/Unit Tests/Tests/View Models/JoinedRoomsViewModelTests.swift
+++ b/Unit Tests/Tests/View Models/JoinedRoomsViewModelTests.swift
@@ -23,7 +23,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let stateToReturn: JoinedRoomsRepository.State = .initializing(error: nil)
+        let stateToReturn: JoinedRoomsRepositoryState = .initializing(error: nil)
         
         let stubJoinedRoomsRepository = StubJoinedRoomsRepository(state_toReturn: stateToReturn, delegate_expectedSetCallCount: 1)
         
@@ -46,7 +46,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let stateToReturn: JoinedRoomsRepository.State = .initializing(error: nil)
+        let stateToReturn: JoinedRoomsRepositoryState = .initializing(error: nil)
         
         let stubJoinedRoomsRepository = StubJoinedRoomsRepository(state_toReturn: stateToReturn, delegate_expectedSetCallCount: 1)
         
@@ -71,8 +71,8 @@ class JoinedRoomsViewModelTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let initialStateToReturn: JoinedRoomsRepository.State = .initializing(error: nil)
-        let modifiedStateToReturn: JoinedRoomsRepository.State = .connected(rooms: [self.room], changeReason: nil)
+        let initialStateToReturn: JoinedRoomsRepositoryState = .initializing(error: nil)
+        let modifiedStateToReturn: JoinedRoomsRepositoryState = .connected(rooms: [self.room], changeReason: nil)
         
         let stubJoinedRoomsRepository = StubJoinedRoomsRepository(state_toReturn: initialStateToReturn, delegate_expectedSetCallCount: 1)
         let stubDelegate = StubJoinedRoomsViewModelDelegate(didUpdateState_expectedCallCount: 1)
@@ -111,8 +111,8 @@ class JoinedRoomsViewModelTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let initialStateToReturn: JoinedRoomsRepository.State = .connected(rooms: [self.room], changeReason: nil)
-        let modifiedStateToReturn: JoinedRoomsRepository.State = .degraded(rooms: [self.room], error: FakeError.firstError, changeReason: nil)
+        let initialStateToReturn: JoinedRoomsRepositoryState = .connected(rooms: [self.room], changeReason: nil)
+        let modifiedStateToReturn: JoinedRoomsRepositoryState = .degraded(rooms: [self.room], error: FakeError.firstError, changeReason: nil)
         
         let stubJoinedRoomsRepository = StubJoinedRoomsRepository(state_toReturn: initialStateToReturn, delegate_expectedSetCallCount: 1)
         let stubDelegate = StubJoinedRoomsViewModelDelegate(didUpdateState_expectedCallCount: 1)

--- a/Unit Tests/Tests/View Models/JoinedRoomsViewModelTests.swift
+++ b/Unit Tests/Tests/View Models/JoinedRoomsViewModelTests.swift
@@ -60,7 +60,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         /*----- THEN -----*/
         /******************/
         
-        let expectedState: JoinedRoomsViewModel.State = .initializing(error: nil)
+        let expectedState: JoinedRoomsViewModelState = .initializing(error: nil)
         
         XCTAssertEqual(sut.state, expectedState)
     }
@@ -99,7 +99,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         
         wait(for: [expectation], timeout: 1.0)
         
-        let expectedState: JoinedRoomsViewModel.State = .connected(rooms: [self.room], changeReason: nil)
+        let expectedState: JoinedRoomsViewModelState = .connected(rooms: [self.room], changeReason: nil)
         
         XCTAssertEqual(stubDelegate.didUpdateState_actualCallCount, 1)
         XCTAssertEqual(stubDelegate.didUpdateState_stateLastReceived, expectedState)
@@ -139,7 +139,7 @@ class JoinedRoomsViewModelTests: XCTestCase {
         
         wait(for: [expectation], timeout: 1.0)
         
-        let expectedState: JoinedRoomsViewModel.State = .degraded(rooms: [self.room], error: FakeError.firstError, changeReason: nil)
+        let expectedState: JoinedRoomsViewModelState = .degraded(rooms: [self.room], error: FakeError.firstError, changeReason: nil)
         
         XCTAssertEqual(stubDelegate.didUpdateState_actualCallCount, 1)
         XCTAssertEqual(stubDelegate.didUpdateState_stateLastReceived, expectedState)

--- a/Unit Tests/Tests/View Models/States/JoinedRoomsViewModelStateTests.swift
+++ b/Unit Tests/Tests/View Models/States/JoinedRoomsViewModelStateTests.swift
@@ -102,7 +102,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryState: JoinedRoomsRepository.State = .initializing(error: self.firstError)
+        let repositoryState: JoinedRoomsRepositoryState = .initializing(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -125,7 +125,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryState: JoinedRoomsRepository.State = .connected(rooms: Set(self.firstRooms), changeReason: nil)
+        let repositoryState: JoinedRoomsRepositoryState = .connected(rooms: Set(self.firstRooms), changeReason: nil)
         
         /******************/
         /*----- WHEN -----*/
@@ -148,7 +148,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryState: JoinedRoomsRepository.State = .degraded(rooms: Set(self.firstRooms), error: self.firstError, changeReason: nil)
+        let repositoryState: JoinedRoomsRepositoryState = .degraded(rooms: Set(self.firstRooms), error: self.firstError, changeReason: nil)
         
         /******************/
         /*----- WHEN -----*/
@@ -171,7 +171,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let repositoryState: JoinedRoomsRepository.State = .closed(error: self.firstError)
+        let repositoryState: JoinedRoomsRepositoryState = .closed(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -199,7 +199,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
             self.fourthRoom,
             self.fifthRoom
         ]
-        let repositoryState: JoinedRoomsRepository.State = .connected(rooms: rooms, changeReason: nil)
+        let repositoryState: JoinedRoomsRepositoryState = .connected(rooms: rooms, changeReason: nil)
         
         /******************/
         /*----- WHEN -----*/
@@ -232,7 +232,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
             self.firstRoom,
             self.thirdRoom
         ]
-        let repositoryState: JoinedRoomsRepository.State = .connected(rooms: rooms, changeReason: nil)
+        let repositoryState: JoinedRoomsRepositoryState = .connected(rooms: rooms, changeReason: nil)
         
         /******************/
         /*----- WHEN -----*/
@@ -268,7 +268,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
             self.firstRoom,
             self.thirdRoom
         ]
-        let repositoryState: JoinedRoomsRepository.State = .connected(rooms: rooms, changeReason: nil)
+        let repositoryState: JoinedRoomsRepositoryState = .connected(rooms: rooms, changeReason: nil)
         
         /******************/
         /*----- WHEN -----*/

--- a/Unit Tests/Tests/View Models/States/JoinedRoomsViewModelStateTests.swift
+++ b/Unit Tests/Tests/View Models/States/JoinedRoomsViewModelStateTests.swift
@@ -108,13 +108,13 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.State(repositoryState: repositoryState, previousRooms: nil)
+        let result = JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: nil)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.State = .initializing(error: self.firstError)
+        let expectedValue: JoinedRoomsViewModelState = .initializing(error: self.firstError)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -131,13 +131,13 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.State(repositoryState: repositoryState, previousRooms: nil)
+        let result = JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: nil)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.State = .connected(rooms: self.firstRooms, changeReason: nil)
+        let expectedValue: JoinedRoomsViewModelState = .connected(rooms: self.firstRooms, changeReason: nil)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -154,13 +154,13 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.State(repositoryState: repositoryState, previousRooms: nil)
+        let result = JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: nil)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: nil)
+        let expectedValue: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: nil)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -177,13 +177,13 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.State(repositoryState: repositoryState, previousRooms: nil)
+        let result = JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: nil)
         
         /******************/
         /*----- THEN -----*/
         /******************/
         
-        let expectedValue: JoinedRoomsViewModel.State = .closed(error: self.firstError)
+        let expectedValue: JoinedRoomsViewModelState = .closed(error: self.firstError)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -205,7 +205,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.State(repositoryState: repositoryState, previousRooms: nil)
+        let result = JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: nil)
         
         /******************/
         /*----- THEN -----*/
@@ -216,7 +216,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
             self.fifthRoom,
             self.sixthRoom
         ]
-        let expectedValue: JoinedRoomsViewModel.State = .connected(rooms: expectedRooms, changeReason: nil)
+        let expectedValue: JoinedRoomsViewModelState = .connected(rooms: expectedRooms, changeReason: nil)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -238,7 +238,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.State(repositoryState: repositoryState, previousRooms: nil)
+        let result = JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: nil)
         
         /******************/
         /*----- THEN -----*/
@@ -249,7 +249,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
             self.secondRoom,
             self.thirdRoom
         ]
-        let expectedValue: JoinedRoomsViewModel.State = .connected(rooms: expectedRooms, changeReason: nil)
+        let expectedValue: JoinedRoomsViewModelState = .connected(rooms: expectedRooms, changeReason: nil)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -274,7 +274,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*----- WHEN -----*/
         /******************/
         
-        let result = JoinedRoomsViewModel.State(repositoryState: repositoryState, previousRooms: nil)
+        let result = JoinedRoomsViewModelState(repositoryState: repositoryState, previousRooms: nil)
         
         /******************/
         /*----- THEN -----*/
@@ -288,7 +288,7 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
             self.fifthRoom,
             self.sixthRoom
         ]
-        let expectedValue: JoinedRoomsViewModel.State = .connected(rooms: expectedRooms, changeReason: nil)
+        let expectedValue: JoinedRoomsViewModelState = .connected(rooms: expectedRooms, changeReason: nil)
         
         XCTAssertEqual(result, expectedValue)
     }
@@ -299,10 +299,10 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let initializingState: JoinedRoomsViewModel.State = .initializing(error: self.firstError)
-        let connectedState: JoinedRoomsViewModel.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let degradedState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let closedState: JoinedRoomsViewModel.State = .closed(error: self.firstError)
+        let initializingState: JoinedRoomsViewModelState = .initializing(error: self.firstError)
+        let connectedState: JoinedRoomsViewModelState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let degradedState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let closedState: JoinedRoomsViewModelState = .closed(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -337,8 +337,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .initializing(error: self.firstError)
-        let secondState: JoinedRoomsViewModel.State = .initializing(error: self.firstError)
+        let firstState: JoinedRoomsViewModelState = .initializing(error: self.firstError)
+        let secondState: JoinedRoomsViewModelState = .initializing(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -359,8 +359,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .initializing(error: self.firstError)
-        let secondState: JoinedRoomsViewModel.State = .initializing(error: self.secondError)
+        let firstState: JoinedRoomsViewModelState = .initializing(error: self.firstError)
+        let secondState: JoinedRoomsViewModelState = .initializing(error: self.secondError)
         
         /******************/
         /*----- WHEN -----*/
@@ -381,8 +381,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .closed(error: self.firstError)
-        let secondState: JoinedRoomsViewModel.State = .closed(error: self.firstError)
+        let firstState: JoinedRoomsViewModelState = .closed(error: self.firstError)
+        let secondState: JoinedRoomsViewModelState = .closed(error: self.firstError)
         
         /******************/
         /*----- WHEN -----*/
@@ -403,8 +403,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .closed(error: self.firstError)
-        let secondState: JoinedRoomsViewModel.State = .closed(error: self.secondError)
+        let firstState: JoinedRoomsViewModelState = .closed(error: self.firstError)
+        let secondState: JoinedRoomsViewModelState = .closed(error: self.secondError)
         
         /******************/
         /*----- WHEN -----*/
@@ -425,8 +425,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsViewModel.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsViewModelState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsViewModelState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -447,8 +447,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsViewModel.State = .connected(rooms: self.secondRooms, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsViewModelState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsViewModelState = .connected(rooms: self.secondRooms, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -469,8 +469,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsViewModel.State = .connected(rooms: self.firstRooms, changeReason: self.secondChangeReason)
+        let firstState: JoinedRoomsViewModelState = .connected(rooms: self.firstRooms, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsViewModelState = .connected(rooms: self.firstRooms, changeReason: self.secondChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -491,8 +491,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -513,8 +513,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsViewModel.State = .degraded(rooms: self.secondRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsViewModelState = .degraded(rooms: self.secondRooms, error: self.firstError, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -535,8 +535,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.secondError, changeReason: self.firstChangeReason)
+        let firstState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.secondError, changeReason: self.firstChangeReason)
         
         /******************/
         /*----- WHEN -----*/
@@ -557,8 +557,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
         /*---- GIVEN -----*/
         /******************/
         
-        let firstState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
-        let secondState: JoinedRoomsViewModel.State = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.secondChangeReason)
+        let firstState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.firstChangeReason)
+        let secondState: JoinedRoomsViewModelState = .degraded(rooms: self.firstRooms, error: self.firstError, changeReason: self.secondChangeReason)
         
         /******************/
         /*----- WHEN -----*/

--- a/Unit Tests/Tests/View Models/States/JoinedRoomsViewModelStateTests.swift
+++ b/Unit Tests/Tests/View Models/States/JoinedRoomsViewModelStateTests.swift
@@ -16,8 +16,8 @@ class JoinedRoomsViewModelStateTests: XCTestCase {
     var firstRooms: [Room]!
     var secondRooms: [Room]!
     
-    var firstChangeReason: JoinedRoomsViewModel.ChangeReason!
-    var secondChangeReason: JoinedRoomsViewModel.ChangeReason!
+    var firstChangeReason: JoinedRoomsViewModelChangeReason!
+    var secondChangeReason: JoinedRoomsViewModelChangeReason!
     
     var firstError: Error!
     var secondError: Error!


### PR DESCRIPTION
### What?

This PR exposes `JoinedRoomsRepository` and `JoinedRoomsViewModel` in the public API as protocols.

### Why?

Increased testability.

----
