### PR TITLE
OKP Crash Fix

### DIFF
--- a/Chatkit/Subscriptions/Instance/ResumableSubscription.swift
+++ b/Chatkit/Subscriptions/Instance/ResumableSubscription.swift
@@ -1,9 +1,18 @@
 import class PusherPlatform.PPResumableSubscription
 
 protocol ResumableSubscription: AnyObject {
-    var onOpen: (() -> Void)? { get set }
-    var onError: ((Error) -> Void)? { get set }
-    func end()
+    func terminate()
 }
 
-extension PusherPlatform.PPResumableSubscription: ResumableSubscription {}
+extension PusherPlatform.PPResumableSubscription: ResumableSubscription {
+    
+    func terminate() {
+        self.onOpen = nil
+        self.onOpening = nil
+        self.onResuming = nil
+        self.onEvent = nil
+        self.onError = nil
+        self.onEnd = nil
+        self.end()
+    }
+}

--- a/Chatkit/Subscriptions/Subscription.swift
+++ b/Chatkit/Subscriptions/Subscription.swift
@@ -119,9 +119,7 @@ class ConcreteSubscription: Subscription {
             
         case let .subscribingStageTwo(_, resumableSubscription, completions):
             
-            resumableSubscription.onOpen = nil
-            resumableSubscription.onError = nil
-            resumableSubscription.end()
+            resumableSubscription.terminate()
             
             state = .notSubscribed
             
@@ -135,9 +133,7 @@ class ConcreteSubscription: Subscription {
             
         case let .subscribed(_, resumableSubscription):
             
-            resumableSubscription.onOpen = nil
-            resumableSubscription.onError = nil
-            resumableSubscription.end()
+            resumableSubscription.terminate()
             
             state = .notSubscribed
         }
@@ -214,9 +210,7 @@ class ConcreteSubscription: Subscription {
                 
             case let .subscribingStageTwo(_, resumableSubscription, completions):
                 
-                resumableSubscription.onOpen = nil
-                resumableSubscription.onError = nil
-                resumableSubscription.end()
+                resumableSubscription.terminate()
                 
                 // The ORDER of the code here is VITAL:
                 //   We MUST set the state before we call the delegate/completions
@@ -267,9 +261,7 @@ class ConcreteSubscription: Subscription {
                 
             case let .subscribingStageTwo(_, resumableSubscription, completions):
                 
-                resumableSubscription.onOpen = nil
-                resumableSubscription.onError = nil
-                resumableSubscription.end()
+                resumableSubscription.terminate()
                 
                 // The ORDER of the code here is VITAL:
                 //   We MUST set the state before we call the delegate/completions

--- a/Test Utilities/Doubles/Subscriptions/Instance/InstanceWrapper.swift
+++ b/Test Utilities/Doubles/Subscriptions/Instance/InstanceWrapper.swift
@@ -46,10 +46,10 @@ public class StubInstanceWrapper: DoubleBase, InstanceWrapper {
     private weak var internalStubResumableSubscription: StubResumableSubscription?
 
     public init(subscribeWithResume_outcomes: [SubscribeOutcome] = [],
-                resumableSubscription_end_expected: Bool = false,
+                resumableSubscription_terminate_expected: Bool = false,
                 file: StaticString = #file, line: UInt = #line) {
         self.subscribeWithResume_outcomes = subscribeWithResume_outcomes
-        self.resumableSubscription_end_expected = resumableSubscription_end_expected
+        self.resumableSubscription_terminate_expected = resumableSubscription_terminate_expected
         super.init(file: file, line: line)
     }
     
@@ -61,12 +61,12 @@ public class StubInstanceWrapper: DoubleBase, InstanceWrapper {
         subscribeWithResume_outcomes.append(outcome)
     }
     
-    private var resumableSubscription_end_expected = false
+    private var resumableSubscription_terminate_expected = false
     public func stubResumableSubscriptionEnd() {
         if let internalStubResumableSubscription = internalStubResumableSubscription {
-            internalStubResumableSubscription.increment_end_expectedCallCount()
+            internalStubResumableSubscription.increment_terminate_expectedCallCount()
         } else {
-            resumableSubscription_end_expected = true
+            resumableSubscription_terminate_expected = true
         }
     }
     
@@ -191,14 +191,14 @@ public class StubInstanceWrapper: DoubleBase, InstanceWrapper {
             }
         }
         
-        let end_expectedCallCount: UInt
+        let terminate_expectedCallCount: UInt
         if case .fail = subscribeWithResume_outcome {
-            end_expectedCallCount = 1
+            terminate_expectedCallCount = 1
         } else {
-            end_expectedCallCount = resumableSubscription_end_expected ? 1 : 0
+            terminate_expectedCallCount = resumableSubscription_terminate_expected ? 1 : 0
         }
         
-        let stubResumableSubscription = StubResumableSubscription(end_expectedCallCount: end_expectedCallCount, file: file, line: line)
+        let stubResumableSubscription = StubResumableSubscription(terminate_expectedCallCount: terminate_expectedCallCount, file: file, line: line)
         internalStubResumableSubscription = stubResumableSubscription
         return stubResumableSubscription
     }

--- a/Test Utilities/Doubles/Subscriptions/Instance/ResumableSubscription.swift
+++ b/Test Utilities/Doubles/Subscriptions/Instance/ResumableSubscription.swift
@@ -3,27 +3,7 @@ import XCTest
 
 public class DummyResumableSubscription: DummyBase, ResumableSubscription {
     
-    public var onOpen: (() -> Void)? {
-        get {
-            DummyFail(sender: self, function: #function)
-            return {}
-        }
-        set {
-            DummyFail(sender: self, function: #function)
-        }
-    }
-    
-    public var onError: ((Error) -> Void)? {
-           get {
-               DummyFail(sender: self, function: #function)
-               return { error in () }
-           }
-           set {
-               DummyFail(sender: self, function: #function)
-           }
-       }
-    
-    public func end() {
+    public func terminate() {
         DummyFail(sender: self, function: #function)
     }
     
@@ -31,29 +11,24 @@ public class DummyResumableSubscription: DummyBase, ResumableSubscription {
 
 public class StubResumableSubscription: DoubleBase, ResumableSubscription {
     
-    // This is marked `internal` so that the `StubNetworking` wrapper can interact with it
-    private var end_expectedCallCount: UInt
-    public private(set) var end_actualCallCount: UInt = 0
+    private var terminate_expectedCallCount: UInt
+    public private(set) var terminate_actualCallCount: UInt = 0
     
-    public init(end_expectedCallCount: UInt = 0,
+    public init(terminate_expectedCallCount: UInt = 0,
                 file: StaticString = #file, line: UInt = #line) {
         
-        self.end_expectedCallCount = end_expectedCallCount
+        self.terminate_expectedCallCount = terminate_expectedCallCount
         
         super.init(file: file, line: line)
     }
     
-    public func increment_end_expectedCallCount() {
-        end_expectedCallCount += 1
+    public func increment_terminate_expectedCallCount() {
+        terminate_expectedCallCount += 1
     }
     
-    public var onOpen: (() -> Void)?
-    
-    public var onError: ((Error) -> Void)?
-    
-    public func end() {
-        end_actualCallCount += 1
-        guard end_actualCallCount <= end_expectedCallCount else {
+    public func terminate() {
+        terminate_actualCallCount += 1
+        guard terminate_actualCallCount <= terminate_expectedCallCount else {
             XCTFail("Unexpected call of `\(#function)` made to \(String(describing: self))", file: file, line: line)
             return
         }

--- a/Unit Tests/Tests/Subscriptions/ConcreteSubscriptionTests.swift
+++ b/Unit Tests/Tests/Subscriptions/ConcreteSubscriptionTests.swift
@@ -42,7 +42,7 @@ class ConcreteSubscriptionTests: XCTestCase {
                                      stubStore_dispatch_expectedCallCount: UInt = 1,
                                      stubDelegate_didReceivedEvent_expectedCallCount: UInt? = nil,
                                      stubDelegate_didReceivedError_expectedCallCount: UInt? = nil,
-                                     stubResumableSubscription_end_expected: Bool? = nil,
+                                     stubResumableSubscription_terminate_expected: Bool? = nil,
                                      file: StaticString = #file, line: UInt = #line)
         -> (ConcreteSubscription, StubStore, StubInstanceWrapper, StubInstanceWrapperFactory, StubSubscriptionDelegate) {
             
@@ -55,7 +55,7 @@ class ConcreteSubscriptionTests: XCTestCase {
             
             let stubInstanceWrapper = StubInstanceWrapper(
                 subscribeWithResume_outcomes: [.wait],
-                resumableSubscription_end_expected: stubResumableSubscription_end_expected ?? false,
+                resumableSubscription_terminate_expected: stubResumableSubscription_terminate_expected ?? false,
                 file: file, line: line
             )
             
@@ -92,7 +92,7 @@ class ConcreteSubscriptionTests: XCTestCase {
                                            stubStore_dispatch_expectedCallCount: UInt = 2,
                                            stubDelegate_didReceivedEvent_expectedCallCount: UInt? = nil,
                                            stubDelegate_didReceivedError_expectedCallCount: UInt? = nil,
-                                           stubResumableSubscription_end_expected: Bool? = nil,
+                                           stubResumableSubscription_terminate_expected: Bool? = nil,
                                            file: StaticString = #file, line: UInt = #line)
         -> (ConcreteSubscription, StubStore, StubInstanceWrapper, StubInstanceWrapperFactory, StubSubscriptionDelegate, XCTestExpectation.Expectation<VoidResult>) {
             
@@ -101,7 +101,7 @@ class ConcreteSubscriptionTests: XCTestCase {
                                       stubStore_dispatch_expectedCallCount: stubStore_dispatch_expectedCallCount,
                                       stubDelegate_didReceivedEvent_expectedCallCount: stubDelegate_didReceivedEvent_expectedCallCount,
                                       stubDelegate_didReceivedError_expectedCallCount: stubDelegate_didReceivedError_expectedCallCount,
-                                      stubResumableSubscription_end_expected: stubResumableSubscription_end_expected,
+                                      stubResumableSubscription_terminate_expected: stubResumableSubscription_terminate_expected,
                                       file: file, line: line)
 
             let expectation = XCTestExpectation.Subscription.subscribe
@@ -124,7 +124,7 @@ class ConcreteSubscriptionTests: XCTestCase {
         stubStore_dispatch_expectedCallCount: UInt = 2,
         stubDelegate_didReceivedEvent_expectedCallCount: UInt? = nil,
         stubDelegate_didReceivedError_expectedCallCount: UInt? = nil,
-        stubResumableSubscription_end_expected: Bool? = nil,
+        stubResumableSubscription_terminate_expected: Bool? = nil,
         file: StaticString = #file, line: UInt = #line
     )
         -> (ConcreteSubscription, StubStore, StubInstanceWrapper, StubInstanceWrapperFactory, StubSubscriptionDelegate, XCTestExpectation.Expectation<VoidResult>, XCTestExpectation.Expectation<VoidResult>) {
@@ -134,7 +134,7 @@ class ConcreteSubscriptionTests: XCTestCase {
                                         stubStore_dispatch_expectedCallCount: stubStore_dispatch_expectedCallCount,
                                         stubDelegate_didReceivedEvent_expectedCallCount: stubDelegate_didReceivedEvent_expectedCallCount,
                                         stubDelegate_didReceivedError_expectedCallCount: stubDelegate_didReceivedError_expectedCallCount,
-                                        stubResumableSubscription_end_expected: stubResumableSubscription_end_expected,
+                                        stubResumableSubscription_terminate_expected: stubResumableSubscription_terminate_expected,
                                         file: file, line: line)
 
         let secondExpectation = XCTestExpectation.Subscription.subscribe
@@ -157,7 +157,7 @@ class ConcreteSubscriptionTests: XCTestCase {
                                   stubStore_dispatch_expectedCallCount: UInt = 3,
                                   stubDelegate_didReceivedEvent_expectedCallCount: UInt? = nil,
                                   stubDelegate_didReceivedError_expectedCallCount: UInt? = nil,
-                                  stubResumableSubscription_end_expected: Bool? = nil,
+                                  stubResumableSubscription_terminate_expected: Bool? = nil,
                                   file: StaticString = #file, line: UInt = #line)
         -> (ConcreteSubscription, StubStore, StubInstanceWrapper, StubInstanceWrapperFactory, StubSubscriptionDelegate) {
             
@@ -166,8 +166,8 @@ class ConcreteSubscriptionTests: XCTestCase {
                                             stubStore_dispatch_expectedCallCount: stubStore_dispatch_expectedCallCount,
                                             stubDelegate_didReceivedEvent_expectedCallCount: stubDelegate_didReceivedEvent_expectedCallCount,
                                             stubDelegate_didReceivedError_expectedCallCount: stubDelegate_didReceivedError_expectedCallCount,
-                                            stubResumableSubscription_end_expected:
-                                                stubResumableSubscription_end_expected,
+                                            stubResumableSubscription_terminate_expected:
+                                                stubResumableSubscription_terminate_expected,
                                             file: file, line: line)
             
             let jsonData = "{}".toJsonData()
@@ -431,7 +431,7 @@ class ConcreteSubscriptionTests: XCTestCase {
         let (sut, stubStore, stubInstanceWrapper, stubInstanceWrapperFactory, stubDelegate, expectation)
             = setUp_subscribingStageTwo(forType: subscriptionType,
                                         stubDelegate_didReceivedError_expectedCallCount: 1,
-                                        stubResumableSubscription_end_expected: true)
+                                        stubResumableSubscription_terminate_expected: true)
         
         XCTAssertEqualState(sut.state, .subscribingStageTwo)
         XCTAssertExpectationUnfulfilled(expectation)
@@ -482,7 +482,7 @@ class ConcreteSubscriptionTests: XCTestCase {
             = setUp_subscribingStageTwoWithMultipleWaitingCompletions(
                 forType: subscriptionType,
                 stubDelegate_didReceivedError_expectedCallCount: 1,
-                stubResumableSubscription_end_expected: true
+                stubResumableSubscription_terminate_expected: true
             )
         
         // Confirm setUp
@@ -536,7 +536,7 @@ class ConcreteSubscriptionTests: XCTestCase {
         let (sut, stubStore, stubInstanceWrapper, stubInstanceWrapperFactory, stubDelegate)
             = setUp_subscribed(forType: subscriptionType,
                                stubDelegate_didReceivedError_expectedCallCount: 1,
-                               stubResumableSubscription_end_expected: true)
+                               stubResumableSubscription_terminate_expected: true)
         
         // Confirm setUp
         XCTAssertEqualState(sut.state, .subscribed)
@@ -886,7 +886,7 @@ class ConcreteSubscriptionTests: XCTestCase {
         let (sut, stubStore, stubInstanceWrapper, stubInstanceWrapperFactory, stubDelegate, expectation)
             = setUp_subscribingStageTwo(forType: subscriptionType,
                                         stubDelegate_didReceivedError_expectedCallCount: 1,
-                                        stubResumableSubscription_end_expected: true)
+                                        stubResumableSubscription_terminate_expected: true)
         
         // Confirm setUp
         XCTAssertEqualState(sut.state, .subscribingStageTwo)
@@ -939,7 +939,7 @@ class ConcreteSubscriptionTests: XCTestCase {
             = setUp_subscribingStageTwoWithMultipleWaitingCompletions(
                 forType: subscriptionType,
                 stubDelegate_didReceivedError_expectedCallCount: 1,
-                stubResumableSubscription_end_expected: true
+                stubResumableSubscription_terminate_expected: true
             )
         
         // Confirm setUp
@@ -997,7 +997,7 @@ class ConcreteSubscriptionTests: XCTestCase {
         let (sut, stubStore, stubInstanceWrapper, stubInstanceWrapperFactory, stubDelegate)
             = setUp_subscribed(forType: subscriptionType,
                                stubDelegate_didReceivedError_expectedCallCount: 1,
-                               stubResumableSubscription_end_expected: true)
+                               stubResumableSubscription_terminate_expected: true)
         
         // Confirm setUp
         XCTAssertEqualState(sut.state, .subscribed)
@@ -1043,7 +1043,7 @@ class ConcreteSubscriptionTests: XCTestCase {
         let (sut, stubStore, stubInstanceWrapper, stubInstanceWrapperFactory, stubDelegate, expectation)
             = setUp_subscribingStageTwo(forType: subscriptionType,
                                         stubDelegate_didReceivedError_expectedCallCount: 1,
-                                        stubResumableSubscription_end_expected: true)
+                                        stubResumableSubscription_terminate_expected: true)
         
         // Confirm setUp
         XCTAssertEqualState(sut.state, .subscribingStageTwo)
@@ -1098,7 +1098,7 @@ class ConcreteSubscriptionTests: XCTestCase {
             = setUp_subscribingStageTwoWithMultipleWaitingCompletions(
                 forType: subscriptionType,
                 stubDelegate_didReceivedError_expectedCallCount: 1,
-                stubResumableSubscription_end_expected: true
+                stubResumableSubscription_terminate_expected: true
             )
         
         // Confirm setUp
@@ -1158,7 +1158,7 @@ class ConcreteSubscriptionTests: XCTestCase {
         let (sut, stubStore, stubInstanceWrapper, stubInstanceWrapperFactory, stubDelegate)
             = setUp_subscribed(forType: subscriptionType,
                                stubDelegate_didReceivedError_expectedCallCount: 1,
-                               stubResumableSubscription_end_expected: true)
+                               stubResumableSubscription_terminate_expected: true)
         
         // Confirm setUp
         XCTAssertEqualState(sut.state, .subscribed)


### PR DESCRIPTION

### What?
Ensure that all closures are nill'ed off on a ResumableSubscription before calling `end()`

### Why?
Fixes an infinite recursion crash when attempting to subscribe with a non-existing userId.

