### PR TITLE
Wire model updates

### DIFF
--- a/Chatkit/Networking/Model/Wire.Membership.swift
+++ b/Chatkit/Networking/Model/Wire.Membership.swift
@@ -5,7 +5,7 @@ extension Wire {
     internal struct Membership {
         
         let roomIdentifier: String
-        let userIdentifiers: [String]
+        let userIdentifiers: Set<String>
 
     }
 

--- a/Chatkit/Networking/Model/Wire.Room.swift
+++ b/Chatkit/Networking/Model/Wire.Room.swift
@@ -5,7 +5,6 @@ extension Wire {
     internal struct Room {
         let identifier: String
         let name: String
-        let createdById: String
         let isPrivate: Bool
         let pushNotificationTitleOverride: String?
         let customData: [String: AnyHashable]?
@@ -24,7 +23,6 @@ extension Wire.Room: Decodable {
     private enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case name
-        case createdById = "created_by_id"
         case pushNotificationTitleOverride = "push_notification_title_override"
         case customData = "custom_data"
         case isPrivate = "private"
@@ -44,7 +42,6 @@ extension Wire.Room: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.identifier = try container.decode(String.self, forKey: .identifier)
         self.name = try container.decode(String.self, forKey: .name)
-        self.createdById = try container.decode(String.self, forKey: .createdById)
         self.pushNotificationTitleOverride = try container.decodeIfPresent(String.self, forKey: .pushNotificationTitleOverride)
         self.customData = try container.decodeIfPresent([String: AnyHashable].self, forKey: .customData)
         self.isPrivate = try container.decode(Bool.self, forKey: .isPrivate)

--- a/Functional Tests/Tests/Functional.ChatkitConnected.Tests.swift
+++ b/Functional Tests/Tests/Functional.ChatkitConnected.Tests.swift
@@ -203,7 +203,6 @@ class Functional_ChatkitConnected_Tests: XCTestCase {
                     "room": {
                         "id": "ac43dfef",
                         "name": "Chatkit chat",
-                        "created_by_id": "alice",
                         "private": false,
                         "created_at": "2017-03-23T11:36:42Z",
                         "updated_at": "2017-07-28T22:19:32Z",

--- a/Functional Tests/Tests/Functional.JoinedRoomsProviderInitialised.Tests.swift
+++ b/Functional Tests/Tests/Functional.JoinedRoomsProviderInitialised.Tests.swift
@@ -27,7 +27,6 @@ class Functional_JoinedRoomsRepositoryConnected_Tests: XCTestCase {
                         {
                             "id": "ac43dfef",
                             "name": "Chatkit chat",
-                            "created_by_id": "alice",
                             "private": false,
                             "created_at": "2017-03-23T11:36:42Z",
                             "updated_at": "2017-07-28T22:19:32Z",

--- a/Unit Tests/Tests/Networking/Model/Subscription/UserSubscription/Wire.Event.AddedToRoom+Decodable.Tests.swift
+++ b/Unit Tests/Tests/Networking/Model/Subscription/UserSubscription/Wire.Event.AddedToRoom+Decodable.Tests.swift
@@ -11,7 +11,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-07-28T22:19:32Z",
@@ -132,7 +131,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
         {
             "room": {
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -167,7 +165,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -198,7 +195,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -231,7 +227,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -265,7 +260,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -299,7 +293,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -323,7 +316,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -349,7 +341,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -376,7 +367,6 @@ class WireEventAddedToRoomDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",

--- a/Unit Tests/Tests/Networking/Model/Subscription/UserSubscription/Wire.Event.InitialState+Decodable.Tests.swift
+++ b/Unit Tests/Tests/Networking/Model/Subscription/UserSubscription/Wire.Event.InitialState+Decodable.Tests.swift
@@ -18,7 +18,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -67,7 +66,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -113,7 +111,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -160,7 +157,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -212,7 +208,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -390,7 +385,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
             "rooms": [
                 {
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -441,7 +435,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -482,7 +475,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -525,7 +517,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -569,7 +560,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -619,7 +609,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -657,7 +646,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -697,7 +685,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -738,7 +725,6 @@ class WireEventInitialStateDecodableTests: XCTestCase {
                 {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",

--- a/Unit Tests/Tests/Networking/Model/Subscription/UserSubscription/Wire.Event.RoomUpdated+Decodable.Tests.swift
+++ b/Unit Tests/Tests/Networking/Model/Subscription/UserSubscription/Wire.Event.RoomUpdated+Decodable.Tests.swift
@@ -11,7 +11,6 @@ class WireEventRoomUpdatedDecodableTests: XCTestCase {
             "room": {
                 "id": "ac43dfef",
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",
@@ -72,7 +71,6 @@ class WireEventRoomUpdatedDecodableTests: XCTestCase {
         {
             "room": {
                 "name": "Chatkit chat",
-                "created_by_id": "alice",
                 "private": false,
                 "created_at": "2017-03-23T11:36:42Z",
                 "updated_at": "2017-04-23T11:36:42Z",

--- a/Unit Tests/Tests/Networking/Model/Subscription/Wire.Event.Subscription+Decodable.Tests.swift
+++ b/Unit Tests/Tests/Networking/Model/Subscription/Wire.Event.Subscription+Decodable.Tests.swift
@@ -209,7 +209,6 @@ class WireSubscriptionEventDecodableTests: XCTestCase {
                     {
                         "id": "ac43dfef",
                         "name": "Chatkit chat",
-                        "created_by_id": "alice",
                         "private": false,
                         "created_at": "2017-03-23T11:36:42Z",
                         "updated_at": "2017-07-28T22:19:32Z",
@@ -289,7 +288,6 @@ class WireSubscriptionEventDecodableTests: XCTestCase {
                 "room": {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",
@@ -397,7 +395,6 @@ class WireSubscriptionEventDecodableTests: XCTestCase {
                 "room": {
                     "id": "ac43dfef",
                     "name": "Chatkit chat",
-                    "created_by_id": "alice",
                     "private": false,
                     "created_at": "2017-03-23T11:36:42Z",
                     "updated_at": "2017-07-28T22:19:32Z",

--- a/Unit Tests/Tests/Networking/Model/Wire.Membership+Decodable.Tests.swift
+++ b/Unit Tests/Tests/Networking/Model/Wire.Membership+Decodable.Tests.swift
@@ -2,7 +2,7 @@ import TestUtilities
 import XCTest
 @testable import PusherChatkit
 
-class WireMemebershipDecodableTests: XCTestCase {
+class WireMembershipDecodableTests: XCTestCase {
     
     func test_init_allFieldsValid_entityFullyPopulated() {
         
@@ -10,6 +10,21 @@ class WireMemebershipDecodableTests: XCTestCase {
         {
             "room_id": "ac43dfef",
             "user_ids": ["alice", "carol"],
+        }
+        """.toJsonData()
+        
+        XCTAssertNoThrow(try Wire.Membership(from: jsonData.jsonDecoder())) { membership in
+            XCTAssertEqual(membership.roomIdentifier, "ac43dfef")
+            XCTAssertEqual(membership.userIdentifiers, ["alice", "carol"])
+        }
+    }
+    
+    func test_init_userIdentifierDuplicates_entityFullyPopulatedWithDedupedUserIdentifiers() {
+        
+        let jsonData = """
+        {
+            "room_id": "ac43dfef",
+            "user_ids": ["alice", "carol", "alice"],
         }
         """.toJsonData()
         

--- a/Unit Tests/Tests/Networking/Model/Wire.Room+Decodable.Tests.swift
+++ b/Unit Tests/Tests/Networking/Model/Wire.Room+Decodable.Tests.swift
@@ -10,7 +10,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -26,7 +25,6 @@ class WireRoomDecodableTests: XCTestCase {
         XCTAssertNoThrow(try Wire.Room(from: jsonData.jsonDecoder())) { user in
             XCTAssertEqual(user.identifier, "ac43dfef")
             XCTAssertEqual(user.name, "Chatkit chat")
-            XCTAssertEqual(user.createdById, "alice")
             XCTAssertEqual(user.pushNotificationTitleOverride, "Chatkit")
             XCTAssertEqual(user.customData as? [String: String], ["highlight_color": "blue"])
             XCTAssertEqual(user.isPrivate, false)
@@ -42,7 +40,6 @@ class WireRoomDecodableTests: XCTestCase {
         let jsonData = """
         {
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -66,7 +63,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": null,
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -91,7 +87,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": 123,
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -115,7 +110,6 @@ class WireRoomDecodableTests: XCTestCase {
         let jsonData = """
         {
             "id": "ac43dfef",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -139,7 +133,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": null,
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -164,7 +157,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": 123,
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -183,86 +175,12 @@ class WireRoomDecodableTests: XCTestCase {
                                           "Expected to decode String but found a number instead."])
     }
     
-    func test_init_createdByIdMissing_throws() {
-        
-        let jsonData = """
-        {
-            "id": "ac43dfef",
-            "name": "Chatkit chat",
-            "push_notification_title_override": "Chatkit",
-            "custom_data": {
-                "highlight_color": "blue"
-            },
-            "private": false,
-            "last_message_at": "2020-01-08T14:55:10Z",
-            "created_at": "2017-03-23T11:36:42Z",
-            "updated_at": "2017-04-23T11:36:42Z",
-            "deleted_at": "2017-05-23T11:36:42Z",
-        }
-        """.toJsonData()
-        
-        XCTAssertThrowsError(try Wire.Room(from: jsonData.jsonDecoder()),
-                             containing: ["keyNotFound",
-                                          "\"created_by_id\""])
-    }
-    
-    func test_init_createdByIdNull_throws() {
-        
-        let jsonData = """
-        {
-            "id": "ac43dfef",
-            "name": "Chatkit chat",
-            "created_by_id": null,
-            "push_notification_title_override": "Chatkit",
-            "custom_data": {
-                "highlight_color": "blue"
-            },
-            "private": false,
-            "last_message_at": "2020-01-08T14:55:10Z",
-            "created_at": "2017-03-23T11:36:42Z",
-            "updated_at": "2017-04-23T11:36:42Z",
-            "deleted_at": "2017-05-23T11:36:42Z",
-        }
-        """.toJsonData()
-        
-        XCTAssertThrowsError(try Wire.Room(from: jsonData.jsonDecoder()),
-                             containing: ["valueNotFound",
-                                          "\"created_by_id\"",
-                                          "Expected String value but found null instead."])
-    }
-    
-    func test_init_createdByIdInvalidType_throws() {
-        
-        let jsonData = """
-        {
-            "id": "ac43dfef",
-            "name": "Chatkit chat",
-            "created_by_id": 123,
-            "push_notification_title_override": "Chatkit",
-            "custom_data": {
-                "highlight_color": "blue"
-            },
-            "private": false,
-            "last_message_at": "2020-01-08T14:55:10Z",
-            "created_at": "2017-03-23T11:36:42Z",
-            "updated_at": "2017-04-23T11:36:42Z",
-            "deleted_at": "2017-05-23T11:36:42Z",
-        }
-        """.toJsonData()
-        
-        XCTAssertThrowsError(try Wire.Room(from: jsonData.jsonDecoder()),
-                             containing: ["typeMismatch",
-                                          "\"created_by_id\"",
-                                          "Expected to decode String but found a number instead."])
-    }
-    
     func test_init_pushNotificationTitleOverrideMissing_noProblem() {
         
         let jsonData = """
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "custom_data": {
                 "highlight_color": "blue"
             },
@@ -285,7 +203,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": null,
             "custom_data": {
                 "highlight_color": "blue"
@@ -309,7 +226,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": 123,
             "custom_data": {
                 "highlight_color": "blue"
@@ -334,7 +250,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "private": false,
             "last_message_at": "2020-01-08T14:55:10Z",
@@ -355,7 +270,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": null,
             "private": false,
@@ -377,7 +291,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": 123,
             "private": false,
@@ -403,7 +316,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "missing value"
@@ -418,7 +330,7 @@ class WireRoomDecodableTests: XCTestCase {
         
         XCTAssertThrowsError(try Wire.Room(from: jsonData.jsonDecoder()),
                              containing: ["The given data was not valid JSON.",
-                                          "No value for key in object around character 182."])
+                                          "No value for key in object around character 152."])
     }
     
     func test_init_isPrivateMissing_throws() {
@@ -427,7 +339,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -450,7 +361,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -474,7 +384,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -499,7 +408,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -522,7 +430,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -546,7 +453,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -571,7 +477,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -596,7 +501,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -619,7 +523,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -644,7 +547,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -669,7 +571,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -694,7 +595,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -717,7 +617,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -742,7 +641,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -767,7 +665,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -792,7 +689,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -815,7 +711,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -839,7 +734,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"
@@ -864,7 +758,6 @@ class WireRoomDecodableTests: XCTestCase {
         {
             "id": "ac43dfef",
             "name": "Chatkit chat",
-            "created_by_id": "alice",
             "push_notification_title_override": "Chatkit",
             "custom_data": {
                 "highlight_color": "blue"

--- a/Unit Tests/Tests/Redux/Reducers/MasterReducerTests.swift
+++ b/Unit Tests/Tests/Redux/Reducers/MasterReducerTests.swift
@@ -166,7 +166,6 @@ class MasterReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "third-room",
                     name: "Third",
-                    createdById: "random-user",
                     isPrivate: false,
                     pushNotificationTitleOverride: nil,
                     customData: nil,
@@ -396,7 +395,6 @@ class MasterReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "second-room",
                     name: "Second Room",
-                    createdById: "alice",
                     isPrivate: true,
                     pushNotificationTitleOverride: nil,
                     customData: nil,
@@ -791,7 +789,6 @@ class MasterReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "second-room",
                     name: "Second",
-                    createdById: "alice",
                     isPrivate: true,
                     pushNotificationTitleOverride: nil,
                     customData: nil,
@@ -903,7 +900,6 @@ class MasterReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "second-room",
                     name: "Second Room",
-                    createdById: "alice",
                     isPrivate: true,
                     pushNotificationTitleOverride: nil,
                     customData: nil,

--- a/Unit Tests/Tests/Redux/Reducers/Model/RoomListReducerTests.swift
+++ b/Unit Tests/Tests/Redux/Reducers/Model/RoomListReducerTests.swift
@@ -29,7 +29,6 @@ class RoomsReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "first-room",
                         name: "First",
-                        createdById: "user-id",
                         isPrivate: true,
                         pushNotificationTitleOverride: "title",
                         customData: nil,
@@ -40,7 +39,6 @@ class RoomsReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "second-room",
                         name: "Second",
-                        createdById: "user-id",
                         isPrivate: false,
                         pushNotificationTitleOverride: nil,
                         customData: [
@@ -138,7 +136,6 @@ class RoomsReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "first-room",
                         name: "First",
-                        createdById: "user-id",
                         isPrivate: true,
                         pushNotificationTitleOverride: "title",
                         customData: nil,
@@ -149,7 +146,6 @@ class RoomsReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "second-room",
                         name: "Second",
-                        createdById: "user-id",
                         isPrivate: false,
                         pushNotificationTitleOverride: nil,
                         customData: [
@@ -259,7 +255,6 @@ class RoomsReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "third-room",
                     name: "Third",
-                    createdById: "random-user",
                     isPrivate: false,
                     pushNotificationTitleOverride: nil,
                     customData: nil,
@@ -383,7 +378,6 @@ class RoomsReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "second-room",
                     name: "Second Room",
-                    createdById: "random-user",
                     isPrivate: true,
                     pushNotificationTitleOverride: nil,
                     customData: nil,
@@ -659,7 +653,6 @@ class RoomsReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "second-room",
                     name: "Second Room",
-                    createdById: "alice",
                     isPrivate: true,
                     pushNotificationTitleOverride: nil,
                     customData: nil,
@@ -759,7 +752,6 @@ class RoomsReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "third-room",
                     name: "Third",
-                    createdById: "alice",
                     isPrivate: true,
                     pushNotificationTitleOverride: nil,
                     customData: nil,

--- a/Unit Tests/Tests/Redux/Reducers/Model/UserReducerTests.swift
+++ b/Unit Tests/Tests/Redux/Reducers/Model/UserReducerTests.swift
@@ -29,7 +29,6 @@ class UserReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "first-room",
                         name: "First",
-                        createdById: "user-id",
                         isPrivate: true,
                         pushNotificationTitleOverride: "title",
                         customData: nil,
@@ -40,7 +39,6 @@ class UserReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "second-room",
                         name: "Second",
-                        createdById: "user-id",
                         isPrivate: false,
                         pushNotificationTitleOverride: nil,
                         customData: [

--- a/Unit Tests/Tests/Redux/Reducers/Subscriptions/User Subscription/AddedToRoomReducerTests.swift
+++ b/Unit Tests/Tests/Redux/Reducers/Subscriptions/User Subscription/AddedToRoomReducerTests.swift
@@ -23,7 +23,6 @@ class AddedToRoomReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "third-room",
                     name: "Third",
-                    createdById: "random-user",
                     isPrivate: false,
                     pushNotificationTitleOverride: nil,
                     customData: nil,

--- a/Unit Tests/Tests/Redux/Reducers/Subscriptions/User Subscription/InitialStateReducerTests.swift
+++ b/Unit Tests/Tests/Redux/Reducers/Subscriptions/User Subscription/InitialStateReducerTests.swift
@@ -29,7 +29,6 @@ class InitialStateReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "first-room",
                         name: "First",
-                        createdById: "user-id",
                         isPrivate: true,
                         pushNotificationTitleOverride: "title",
                         customData: nil,
@@ -40,7 +39,6 @@ class InitialStateReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "second-room",
                         name: "Second",
-                        createdById: "user-id",
                         isPrivate: false,
                         pushNotificationTitleOverride: nil,
                         customData: [
@@ -156,7 +154,6 @@ class InitialStateReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "first-room",
                         name: "First",
-                        createdById: "user-id",
                         isPrivate: true,
                         pushNotificationTitleOverride: "title",
                         customData: nil,
@@ -167,7 +164,6 @@ class InitialStateReducerTests: XCTestCase {
                     Wire.Room(
                         identifier: "second-room",
                         name: "Second",
-                        createdById: "user-id",
                         isPrivate: false,
                         pushNotificationTitleOverride: nil,
                         customData: [

--- a/Unit Tests/Tests/Redux/Reducers/Subscriptions/User Subscription/RoomUpdatedReducerTests.swift
+++ b/Unit Tests/Tests/Redux/Reducers/Subscriptions/User Subscription/RoomUpdatedReducerTests.swift
@@ -48,7 +48,6 @@ class RoomUpdatedReducerTests: XCTestCase {
                 room: Wire.Room(
                     identifier: "second-room",
                     name: "Second Room",
-                    createdById: "alice",
                     isPrivate: true,
                     pushNotificationTitleOverride: nil,
                     customData: nil,


### PR DESCRIPTION
### What?
1. Changed `Wire.Membership.userIdentifiers` to a Set (previously an Array)
2. Dropped `Wire.Room.createdById` 


### Why?
1. Makes sense for `Wire.Membership.userIdentifiers` to be a Set because the ids should be unique.
2. We don't think Wire.Room.createdById`  is required

----
